### PR TITLE
PSMC model with roll dependence and updated params

### DIFF
--- a/chandra_models/xija/psmc/psmc_spec.json
+++ b/chandra_models/xija/psmc/psmc_spec.json
@@ -27,6 +27,10 @@
         [
             "2015:076:04:37:42", 
             "2015:078:03:11:26"
+        ], 
+        [
+            "2015:264:18:00:00", 
+            "2015:266:02:00:00"
         ]
     ], 
     "comps": [
@@ -248,21 +252,21 @@
             "name": "dpa_power"
         }
     ], 
-    "datestart": "2014:312:12:02:48.816", 
-    "datestop": "2015:347:11:52:40.816", 
+    "datestart": "2014:312:12:13:44.816", 
+    "datestop": "2015:347:11:36:16.816", 
     "dt": 328.0, 
     "gui_config": {
-        "filename": "/data/baffin/tom/git/chandra_models/chandra_models/xija/psmc/psmc_spec_roll.json", 
+        "filename": "/data/baffin/tom/git/chandra_models/chandra_models/xija/psmc/psmc_spec4.json", 
         "plot_names": [
             "1pdeaat data__time", 
             "1pdeaat resid__time", 
-            "sim_z data__time", 
-            "1pdeaat resid__data"
+            "1pdeaat resid__data", 
+            "psmc_solarheat__pin1at solar_heat__pitch"
         ], 
         "set_data_vals": {}, 
         "size": [
-            1868, 
-            1069
+            1388, 
+            781
         ]
     }, 
     "mval_names": [], 
@@ -276,7 +280,7 @@
             "max": 60.0, 
             "min": -10.0, 
             "name": "val", 
-            "val": 12.0
+            "val": 20.0
         }, 
         {
             "comp_name": "coupling__pin1at__1pdeaat", 
@@ -466,7 +470,7 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_aciss_45", 
-            "val": 3.6357547477636145
+            "val": 3.6838905503727912
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -476,7 +480,7 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_aciss_55", 
-            "val": 3.6742455404641583
+            "val": 3.6428823082668922
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -486,7 +490,7 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_aciss_65", 
-            "val": 2.9515523751198538
+            "val": 2.5791310221962482
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -496,12 +500,12 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_aciss_75", 
-            "val": 2.8339489164965954
+            "val": 2.5976221202186078
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
             "fmt": "{:.4g}", 
-            "frozen": false, 
+            "frozen": true, 
             "full_name": "psmc_solarheat__pin1at__P_aciss_85", 
             "max": 10.0, 
             "min": -10.0, 
@@ -511,7 +515,7 @@
         {
             "comp_name": "psmc_solarheat__pin1at", 
             "fmt": "{:.4g}", 
-            "frozen": false, 
+            "frozen": true, 
             "full_name": "psmc_solarheat__pin1at__P_aciss_95", 
             "max": 10.0, 
             "min": -10.0, 
@@ -521,7 +525,7 @@
         {
             "comp_name": "psmc_solarheat__pin1at", 
             "fmt": "{:.4g}", 
-            "frozen": false, 
+            "frozen": true, 
             "full_name": "psmc_solarheat__pin1at__P_aciss_130", 
             "max": 10.0, 
             "min": -10.0, 
@@ -546,7 +550,7 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_acisi_45", 
-            "val": 3.8690915024077239
+            "val": 3.9369551546088788
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -556,7 +560,7 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_acisi_55", 
-            "val": 3.7949215235275027
+            "val": 3.7570042728627682
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -566,7 +570,7 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_acisi_65", 
-            "val": 3.0175625390575416
+            "val": 2.6301123244524356
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -576,12 +580,12 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_acisi_75", 
-            "val": 2.8655018795955671
+            "val": 2.6396326946321365
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
             "fmt": "{:.4g}", 
-            "frozen": false, 
+            "frozen": true, 
             "full_name": "psmc_solarheat__pin1at__P_acisi_85", 
             "max": 10.0, 
             "min": -10.0, 
@@ -591,7 +595,7 @@
         {
             "comp_name": "psmc_solarheat__pin1at", 
             "fmt": "{:.4g}", 
-            "frozen": false, 
+            "frozen": true, 
             "full_name": "psmc_solarheat__pin1at__P_acisi_95", 
             "max": 10.0, 
             "min": -10.0, 
@@ -601,7 +605,7 @@
         {
             "comp_name": "psmc_solarheat__pin1at", 
             "fmt": "{:.4g}", 
-            "frozen": false, 
+            "frozen": true, 
             "full_name": "psmc_solarheat__pin1at__P_acisi_130", 
             "max": 10.0, 
             "min": -10.0, 
@@ -621,42 +625,42 @@
         {
             "comp_name": "psmc_solarheat__pin1at", 
             "fmt": "{:.4g}", 
-            "frozen": true, 
+            "frozen": false, 
             "full_name": "psmc_solarheat__pin1at__dP_45", 
             "max": 1.0, 
             "min": -1.0, 
             "name": "dP_45", 
-            "val": -0.10450206229177311
+            "val": -0.19295318029373645
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
             "fmt": "{:.4g}", 
-            "frozen": true, 
+            "frozen": false, 
             "full_name": "psmc_solarheat__pin1at__dP_55", 
             "max": 1.0, 
             "min": -1.0, 
             "name": "dP_55", 
-            "val": -0.34845267733121388
+            "val": -0.32764516125984589
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
             "fmt": "{:.4g}", 
-            "frozen": true, 
+            "frozen": false, 
             "full_name": "psmc_solarheat__pin1at__dP_65", 
             "max": 1.0, 
             "min": -1.0, 
             "name": "dP_65", 
-            "val": 0.073170731707317138
+            "val": 0.51674679484842045
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
             "fmt": "{:.4g}", 
-            "frozen": true, 
+            "frozen": false, 
             "full_name": "psmc_solarheat__pin1at__dP_75", 
             "max": 1.0, 
             "min": -1.0, 
             "name": "dP_75", 
-            "val": -0.17073170731707321
+            "val": -0.05851327604837412
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -736,7 +740,7 @@
             "max": 5.0, 
             "min": -5.0, 
             "name": "P_plus_y", 
-            "val": -0.14815788523018594
+            "val": -0.16448912588494521
         }, 
         {
             "comp_name": "solarheat_off_nom_roll", 
@@ -746,7 +750,7 @@
             "max": 5.0, 
             "min": -5.0, 
             "name": "P_minus_y", 
-            "val": -1.8667279793205609
+            "val": -2.653643647390199
         }, 
         {
             "comp_name": "heatsink__pin1at", 

--- a/chandra_models/xija/psmc/psmc_spec.json
+++ b/chandra_models/xija/psmc/psmc_spec.json
@@ -68,6 +68,18 @@
             "name": "pitch"
         }, 
         {
+            "class_name": "Eclipse", 
+            "init_args": [], 
+            "init_kwargs": {}, 
+            "name": "eclipse"
+        }, 
+        {
+            "class_name": "Roll", 
+            "init_args": [], 
+            "init_kwargs": {}, 
+            "name": "roll"
+        }, 
+        {
             "class_name": "SimZ", 
             "init_args": [], 
             "init_kwargs": {}, 
@@ -166,6 +178,20 @@
             "name": "psmc_solarheat__pin1at"
         }, 
         {
+            "class_name": "SolarHeatOffNomRoll", 
+            "init_args": [
+                "pin1at"
+            ], 
+            "init_kwargs": {
+                "P_minus_y": 0.0, 
+                "P_plus_y": 0.0, 
+                "eclipse_comp": "eclipse", 
+                "pitch_comp": "pitch", 
+                "roll_comp": "roll"
+            }, 
+            "name": "solarheat_off_nom_roll__pin1at"
+        }, 
+        {
             "class_name": "HeatSink", 
             "init_args": [
                 "pin1at"
@@ -222,17 +248,16 @@
             "name": "dpa_power"
         }
     ], 
-    "datestart": "2015:218:12:00:48.816", 
-    "datestop": "2015:302:11:50:48.816", 
+    "datestart": "2014:312:12:02:48.816", 
+    "datestop": "2015:347:11:52:40.816", 
     "dt": 328.0, 
     "gui_config": {
-        "filename": "/data/marple1/chandra/acis/thermal_models/psmc_models/2015_10_30/psmc_model_spec_baseline.json", 
+        "filename": "/data/baffin/tom/git/chandra_models/chandra_models/xija/psmc/psmc_spec_roll.json", 
         "plot_names": [
             "1pdeaat data__time", 
             "1pdeaat resid__time", 
             "sim_z data__time", 
-            "pitch data__time", 
-            "ccd_count data__time"
+            "1pdeaat resid__data"
         ], 
         "set_data_vals": {}, 
         "size": [
@@ -251,7 +276,7 @@
             "max": 60.0, 
             "min": -10.0, 
             "name": "val", 
-            "val": 22.765957446808514
+            "val": 12.0
         }, 
         {
             "comp_name": "coupling__pin1at__1pdeaat", 
@@ -441,7 +466,7 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_aciss_45", 
-            "val": 4.2
+            "val": 3.6357547477636145
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -451,57 +476,57 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_aciss_55", 
-            "val": 3.8
+            "val": 3.6742455404641583
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
             "fmt": "{:.4g}", 
-            "frozen": true, 
+            "frozen": false, 
             "full_name": "psmc_solarheat__pin1at__P_aciss_65", 
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_aciss_65", 
-            "val": 3.2000000000000002
+            "val": 2.9515523751198538
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
             "fmt": "{:.4g}", 
-            "frozen": true, 
+            "frozen": false, 
             "full_name": "psmc_solarheat__pin1at__P_aciss_75", 
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_aciss_75", 
-            "val": 3.2000000000000002
+            "val": 2.8339489164965954
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
             "fmt": "{:.4g}", 
-            "frozen": true, 
+            "frozen": false, 
             "full_name": "psmc_solarheat__pin1at__P_aciss_85", 
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_aciss_85", 
-            "val": 2.3049942479096841
+            "val": 2.2503587648991723
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
             "fmt": "{:.4g}", 
-            "frozen": true, 
+            "frozen": false, 
             "full_name": "psmc_solarheat__pin1at__P_aciss_95", 
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_aciss_95", 
-            "val": 1.8286621543586681
+            "val": 1.9987565696159506
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
             "fmt": "{:.4g}", 
-            "frozen": true, 
+            "frozen": false, 
             "full_name": "psmc_solarheat__pin1at__P_aciss_130", 
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_aciss_130", 
-            "val": 1.3360746770012804
+            "val": 1.147818577371873
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -521,7 +546,7 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_acisi_45", 
-            "val": 4.0537562388237784
+            "val": 3.8690915024077239
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -531,57 +556,57 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_acisi_55", 
-            "val": 3.7560626504185217
+            "val": 3.7949215235275027
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
             "fmt": "{:.4g}", 
-            "frozen": true, 
+            "frozen": false, 
             "full_name": "psmc_solarheat__pin1at__P_acisi_65", 
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_acisi_65", 
-            "val": 3.0236266224516135
+            "val": 3.0175625390575416
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
             "fmt": "{:.4g}", 
-            "frozen": true, 
+            "frozen": false, 
             "full_name": "psmc_solarheat__pin1at__P_acisi_75", 
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_acisi_75", 
-            "val": 2.5712808386253898
+            "val": 2.8655018795955671
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
             "fmt": "{:.4g}", 
-            "frozen": true, 
+            "frozen": false, 
             "full_name": "psmc_solarheat__pin1at__P_acisi_85", 
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_acisi_85", 
-            "val": 2.2384619542052313
+            "val": 2.2353308159502356
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
             "fmt": "{:.4g}", 
-            "frozen": true, 
+            "frozen": false, 
             "full_name": "psmc_solarheat__pin1at__P_acisi_95", 
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_acisi_95", 
-            "val": 1.7539221007202417
+            "val": 1.9669424975063778
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
             "fmt": "{:.4g}", 
-            "frozen": true, 
+            "frozen": false, 
             "full_name": "psmc_solarheat__pin1at__P_acisi_130", 
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_acisi_130", 
-            "val": 1.2013719512195122
+            "val": 1.0916661687437748
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -596,22 +621,22 @@
         {
             "comp_name": "psmc_solarheat__pin1at", 
             "fmt": "{:.4g}", 
-            "frozen": false, 
+            "frozen": true, 
             "full_name": "psmc_solarheat__pin1at__dP_45", 
             "max": 1.0, 
             "min": -1.0, 
             "name": "dP_45", 
-            "val": -0.23878723308089458
+            "val": -0.10450206229177311
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
             "fmt": "{:.4g}", 
-            "frozen": false, 
+            "frozen": true, 
             "full_name": "psmc_solarheat__pin1at__dP_55", 
             "max": 1.0, 
             "min": -1.0, 
             "name": "dP_55", 
-            "val": -0.35627079607094397
+            "val": -0.34845267733121388
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -702,6 +727,26 @@
             "min": -1.0, 
             "name": "dh_heater", 
             "val": 0.19558400300882722
+        }, 
+        {
+            "comp_name": "solarheat_off_nom_roll", 
+            "fmt": "{:.4g}", 
+            "frozen": false, 
+            "full_name": "solarheat_off_nom_roll__P_plus_y", 
+            "max": 5.0, 
+            "min": -5.0, 
+            "name": "P_plus_y", 
+            "val": -0.14815788523018594
+        }, 
+        {
+            "comp_name": "solarheat_off_nom_roll", 
+            "fmt": "{:.4g}", 
+            "frozen": false, 
+            "full_name": "solarheat_off_nom_roll__P_minus_y", 
+            "max": 5.0, 
+            "min": -5.0, 
+            "name": "P_minus_y", 
+            "val": -1.8667279793205609
         }, 
         {
             "comp_name": "heatsink__pin1at", 

--- a/chandra_models/xija/psmc/psmc_spec.json
+++ b/chandra_models/xija/psmc/psmc_spec.json
@@ -29,8 +29,12 @@
             "2015:078:03:11:26"
         ], 
         [
-            "2015:264:18:00:00", 
-            "2015:266:02:00:00"
+            "2015:264:04:35:00", 
+            "2015:266:05:00:00"
+        ],
+        [
+            "2016:063:17:11:00", 
+            "2016:065:04:27:00"
         ]
     ], 
     "comps": [
@@ -177,7 +181,8 @@
                         1.45, 
                         1.476175
                     ]
-                ]
+                ], 
+                "epoch": "2015:250"
             }, 
             "name": "psmc_solarheat__pin1at"
         }, 
@@ -252,21 +257,25 @@
             "name": "dpa_power"
         }
     ], 
-    "datestart": "2014:312:12:13:44.816", 
-    "datestop": "2015:347:11:36:16.816", 
+    "datestart": "2015:175:12:05:20.816", 
+    "datestop": "2016:010:11:49:20.816", 
     "dt": 328.0, 
     "gui_config": {
-        "filename": "/data/baffin/tom/git/chandra_models/chandra_models/xija/psmc/psmc_spec4.json", 
+        "autoscale": false, 
+        "filename": "/data/baffin/tom/git/chandra_models/chandra_models/xija/psmc/fit3_psmc_spec.json", 
         "plot_names": [
             "1pdeaat data__time", 
             "1pdeaat resid__time", 
+            "sim_z data__time", 
+            "roll data__time", 
+            "pitch data__time", 
             "1pdeaat resid__data", 
             "psmc_solarheat__pin1at solar_heat__pitch"
         ], 
         "set_data_vals": {}, 
         "size": [
-            1388, 
-            781
+            1868, 
+            1069
         ]
     }, 
     "mval_names": [], 
@@ -280,7 +289,7 @@
             "max": 60.0, 
             "min": -10.0, 
             "name": "val", 
-            "val": 20.0
+            "val": 12.0
         }, 
         {
             "comp_name": "coupling__pin1at__1pdeaat", 
@@ -290,7 +299,7 @@
             "max": 200.0, 
             "min": 2.0, 
             "name": "tau", 
-            "val": 72.948239182122492
+            "val": 76.548239182122501
         }, 
         {
             "comp_name": "coupling__1pdeaat__pin1at", 
@@ -310,7 +319,7 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_hrcs_45", 
-            "val": 2.1142727948132762
+            "val": 1.9747709788205023
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -320,7 +329,7 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_hrcs_55", 
-            "val": 2.1233373118709253
+            "val": 1.869583686318248
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -330,7 +339,7 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_hrcs_65", 
-            "val": 1.2195121951219523
+            "val": 1.5975451513949868
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -340,7 +349,7 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_hrcs_75", 
-            "val": 2.0
+            "val": 2.0808163664155854
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -350,7 +359,7 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_hrcs_85", 
-            "val": 2.0591776106511999
+            "val": 0.88362633628040865
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -360,7 +369,7 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_hrcs_95", 
-            "val": 1.8999999999999999
+            "val": 1.9959530309542404
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -370,7 +379,7 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_hrcs_130", 
-            "val": 1.6669988847909485
+            "val": 2.2898603709308514
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -380,7 +389,7 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_hrcs_170", 
-            "val": 2.6354776821184727
+            "val": 2.6836579308120476
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -390,7 +399,7 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_hrci_45", 
-            "val": 2.7773522646784885
+            "val": 2.5598752928973343
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -400,7 +409,7 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_hrci_55", 
-            "val": 3.6147347888668637
+            "val": 2.8481774981275567
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -410,7 +419,7 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_hrci_65", 
-            "val": 2.9502584085923047
+            "val": 1.9861723911280034
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -420,7 +429,7 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_hrci_75", 
-            "val": 2.1195354545594967
+            "val": 1.1949533094228291
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -430,7 +439,7 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_hrci_85", 
-            "val": 2.0005634198367455
+            "val": 1.6296758041996964
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -440,7 +449,7 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_hrci_95", 
-            "val": 1.9320503440857859
+            "val": 1.5088402341160105
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -450,7 +459,7 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_hrci_130", 
-            "val": 1.7894266639022289
+            "val": 2.2499176448845155
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -460,47 +469,47 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_hrci_170", 
-            "val": -1.9078634974902169
+            "val": 1.8632983793564364
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
             "fmt": "{:.4g}", 
-            "frozen": false, 
+            "frozen": true, 
             "full_name": "psmc_solarheat__pin1at__P_aciss_45", 
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_aciss_45", 
-            "val": 3.6838905503727912
+            "val": 3.9407532133016678
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
             "fmt": "{:.4g}", 
-            "frozen": false, 
+            "frozen": true, 
             "full_name": "psmc_solarheat__pin1at__P_aciss_55", 
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_aciss_55", 
-            "val": 3.6428823082668922
+            "val": 3.4031213767102599
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
             "fmt": "{:.4g}", 
-            "frozen": false, 
+            "frozen": true, 
             "full_name": "psmc_solarheat__pin1at__P_aciss_65", 
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_aciss_65", 
-            "val": 2.5791310221962482
+            "val": 3.1332996218346323
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
             "fmt": "{:.4g}", 
-            "frozen": false, 
+            "frozen": true, 
             "full_name": "psmc_solarheat__pin1at__P_aciss_75", 
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_aciss_75", 
-            "val": 2.5976221202186078
+            "val": 2.5992718644173269
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -510,7 +519,7 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_aciss_85", 
-            "val": 2.2503587648991723
+            "val": 2.1464540001572416
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -520,7 +529,7 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_aciss_95", 
-            "val": 1.9987565696159506
+            "val": 1.671956386253606
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -530,7 +539,7 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_aciss_130", 
-            "val": 1.147818577371873
+            "val": 1.7680952950863937
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -540,47 +549,47 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_aciss_170", 
-            "val": 2.065492617521941
+            "val": 1.9946246537499412
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
             "fmt": "{:.4g}", 
-            "frozen": false, 
+            "frozen": true, 
             "full_name": "psmc_solarheat__pin1at__P_acisi_45", 
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_acisi_45", 
-            "val": 3.9369551546088788
+            "val": 3.7679268625745133
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
             "fmt": "{:.4g}", 
-            "frozen": false, 
+            "frozen": true, 
             "full_name": "psmc_solarheat__pin1at__P_acisi_55", 
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_acisi_55", 
-            "val": 3.7570042728627682
+            "val": 3.5714710675709331
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
             "fmt": "{:.4g}", 
-            "frozen": false, 
+            "frozen": true, 
             "full_name": "psmc_solarheat__pin1at__P_acisi_65", 
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_acisi_65", 
-            "val": 2.6301123244524356
+            "val": 3.1173893983644265
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
             "fmt": "{:.4g}", 
-            "frozen": false, 
+            "frozen": true, 
             "full_name": "psmc_solarheat__pin1at__P_acisi_75", 
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_acisi_75", 
-            "val": 2.6396326946321365
+            "val": 2.7572010167659613
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -590,7 +599,7 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_acisi_85", 
-            "val": 2.2353308159502356
+            "val": 2.1246629129450194
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -600,7 +609,7 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_acisi_95", 
-            "val": 1.9669424975063778
+            "val": 1.6810618207250487
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -610,7 +619,7 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_acisi_130", 
-            "val": 1.0916661687437748
+            "val": 1.7358836517501319
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -620,47 +629,47 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_acisi_170", 
-            "val": 1.9782391274533691
+            "val": 1.8992638560367361
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
             "fmt": "{:.4g}", 
-            "frozen": false, 
+            "frozen": true, 
             "full_name": "psmc_solarheat__pin1at__dP_45", 
             "max": 1.0, 
             "min": -1.0, 
             "name": "dP_45", 
-            "val": -0.19295318029373645
+            "val": 0.10000000000000001
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
             "fmt": "{:.4g}", 
-            "frozen": false, 
+            "frozen": true, 
             "full_name": "psmc_solarheat__pin1at__dP_55", 
             "max": 1.0, 
             "min": -1.0, 
             "name": "dP_55", 
-            "val": -0.32764516125984589
+            "val": 0.10000000000000001
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
             "fmt": "{:.4g}", 
-            "frozen": false, 
+            "frozen": true, 
             "full_name": "psmc_solarheat__pin1at__dP_65", 
             "max": 1.0, 
             "min": -1.0, 
             "name": "dP_65", 
-            "val": 0.51674679484842045
+            "val": 0.10000000000000001
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
             "fmt": "{:.4g}", 
-            "frozen": false, 
+            "frozen": true, 
             "full_name": "psmc_solarheat__pin1at__dP_75", 
             "max": 1.0, 
             "min": -1.0, 
             "name": "dP_75", 
-            "val": -0.05851327604837412
+            "val": 0.10000000000000001
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -670,7 +679,7 @@
             "max": 1.0, 
             "min": -1.0, 
             "name": "dP_85", 
-            "val": -0.29278836963255139
+            "val": 0.10000000000000001
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -680,7 +689,7 @@
             "max": 1.0, 
             "min": -1.0, 
             "name": "dP_95", 
-            "val": -0.41683128689786958
+            "val": 0.10000000000000001
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -690,7 +699,7 @@
             "max": 1.0, 
             "min": -1.0, 
             "name": "dP_130", 
-            "val": 0.83188908938476525
+            "val": 0.10000000000000001
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -700,7 +709,7 @@
             "max": 1.0, 
             "min": -1.0, 
             "name": "dP_170", 
-            "val": -0.21684848078755936
+            "val": 0.10000000000000001
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -708,9 +717,9 @@
             "frozen": true, 
             "full_name": "psmc_solarheat__pin1at__tau", 
             "max": 3000.0, 
-            "min": 1000.0, 
+            "min": 10.0, 
             "name": "tau", 
-            "val": 1004.9832529530289
+            "val": 365.0
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -725,12 +734,12 @@
         {
             "comp_name": "psmc_solarheat__pin1at", 
             "fmt": "{:.4g}", 
-            "frozen": true, 
+            "frozen": false, 
             "full_name": "psmc_solarheat__pin1at__dh_heater", 
             "max": 1.0, 
             "min": -1.0, 
             "name": "dh_heater", 
-            "val": 0.19558400300882722
+            "val": 0.17201361253421638
         }, 
         {
             "comp_name": "solarheat_off_nom_roll", 
@@ -740,7 +749,7 @@
             "max": 5.0, 
             "min": -5.0, 
             "name": "P_plus_y", 
-            "val": -0.16448912588494521
+            "val": 0.32077916679488183
         }, 
         {
             "comp_name": "solarheat_off_nom_roll", 
@@ -750,7 +759,7 @@
             "max": 5.0, 
             "min": -5.0, 
             "name": "P_minus_y", 
-            "val": -2.653643647390199
+            "val": -2.6565239425807667
         }, 
         {
             "comp_name": "heatsink__pin1at", 


### PR DESCRIPTION
New PSMC (1PDEAAT) model with off-nominal roll dependence and the following features:

- Fit epoch is set to 2015:250.  This does change the numerical value of the P parameters, but the evaluated solar heat input at recent times is very close to your values.  I have verified that the residual vs. data plot looks similar, and I invite you to do the same.
- Long term evolution (*__dP_*) parameters have been set to 0.1.  When I reset the epoch to 2015:250 (vs. the original of 2013:001) and refit the dP values, the results had a mean of around +0.1, with scatter that is unphysical.  My takeaway is that the data cannot constrain those parameters.  If we had sufficiently fast computers then running "conf" would show large uncertainties on those parameters.  So my recommendation for the PSMC model is to simply maintain all the dP values frozen at 0.1 (per 365 days).  Looking at a fit that extends back for 3 years showed no substantial systematic residuals.  So long as the model is recalibrated at least once a year then there will be no issue.
- With the previous dP values that were scattered all about, and an epoch of 2013:001, that meant that the P values which were being plotted were not representative of what was actually being used around 2016:001 because of the significant extrapolation (which was a strong function of pitch bin).  Using a constant 0.1 cleans this up.
- psmc_solarheat__pin1at__tau was set to 365 days (so the dP are change in P per year).
- I refit solarheat_off_nom_roll__P_plus_y, solarheat_off_nom_roll__P_minus_y, and psmc_solarheat__pin1at__dh_heater.  This was just in "playing-around" mode and saving these updates was not my intent.  You can back out these changes or not, as they don't make a huge difference.
