### PR TITLE
Fix DPA model SolarHeatOffNomRoll component and par names

### DIFF
--- a/chandra_models/xija/dpa/dpa_spec.json
+++ b/chandra_models/xija/dpa/dpa_spec.json
@@ -395,20 +395,20 @@
             "val": -0.09243006653563163
         }, 
         {
-            "comp_name": "solarheat_off_nom_roll", 
+            "comp_name": "solarheat_off_nom_roll__1dpamzt", 
             "fmt": "{:.4g}", 
             "frozen": false, 
-            "full_name": "solarheat_off_nom_roll__P_plus_y", 
+            "full_name": "solarheat_off_nom_roll__1dpamzt__P_plus_y", 
             "max": 5.0, 
             "min": -5.0, 
             "name": "P_plus_y", 
             "val": 1.105281354525487
         }, 
         {
-            "comp_name": "solarheat_off_nom_roll", 
+            "comp_name": "solarheat_off_nom_roll__1dpamzt", 
             "fmt": "{:.4g}", 
             "frozen": false, 
-            "full_name": "solarheat_off_nom_roll__P_minus_y", 
+            "full_name": "solarheat_off_nom_roll__1dpamzt__P_minus_y", 
             "max": 5.0, 
             "min": -5.0, 
             "name": "P_minus_y", 


### PR DESCRIPTION
The component and parameter names for the recent SolarHeatOffNomRoll component do not match the values generated by the class definitions.  This is most likely a result of hand-editing the model spec file.

This does not affect the model results in normal xija computations because those names are not used in this context.  Instead the problem comes in trying to convert the spec file to Python and then back to JSON:

```
ska17-kadi$ python -m xija.convert dpa_spec.json --force
ska17-kadi$ python dpa_spec.py dpa_spec.py.json
Traceback (most recent call last):
  File "dpa_spec.py", line 130, in <module>
    comp = model.get_comp(u'solarheat_off_nom_roll')
  File "/home/aldcroft/git/xija/xija/model.py", line 291, in get_comp
    return None if name is None else self.comp[str(name)]
KeyError: 'solarheat_off_nom_roll'
```

See also https://github.com/sot/xija/pull/39, which would have prevented this issue.
