### PR TITLE
July 2018 recalibration of 1DPAMZT, 1DEAMZT, and 1PDEAAT thermal models

### DIFF
--- a/chandra_models/xija/dea/dea_spec.json
+++ b/chandra_models/xija/dea/dea_spec.json
@@ -115,7 +115,7 @@
             "name": "clocking"
         }, 
         {
-            "class_name": "SolarHeatHrc", 
+            "class_name": "SolarHeatHrcOpts", 
             "init_args": [
                 "1deamzt"
             ], 
@@ -143,7 +143,7 @@
                     0.79
                 ], 
                 "eclipse_comp": "eclipse", 
-                "epoch": "2017:211", 
+                "epoch": "2017:352", 
                 "pitch_comp": "pitch", 
                 "simz_comp": "sim_z", 
                 "var_func": "linear"
@@ -182,17 +182,17 @@
                 "clocking": "clocking", 
                 "fep_count": "fep_count", 
                 "pow_states": [
-                    "0xxx", 
-                    "1xxx", 
-                    "2xxx", 
-                    "3xx0", 
-                    "3xx1", 
-                    "4xxx", 
-                    "55x0", 
-                    "5xxx", 
-                    "66x0", 
-                    "6611", 
-                    "6xxx"
+                    "00xx", 
+                    "x0xx", 
+                    "x1xx", 
+                    "x2xx", 
+                    "x3x0", 
+                    "x3x1", 
+                    "x4xx", 
+                    "x5x0", 
+                    "x5x1", 
+                    "x6x0", 
+                    "x6x1"
                 ], 
                 "vid_board": "vid_board"
             }, 
@@ -207,24 +207,25 @@
             "name": "prop_heat__1deamzt"
         }
     ], 
-    "datestart": "2017:029:12:02:16.816", 
-    "datestop": "2018:029:11:49:28.816", 
+    "datestart": "2017:170:12:05:12.816", 
+    "datestop": "2018:169:23:50:48.816", 
     "dt": 328.0, 
     "gui_config": {
-        "filename": "/home/jzuhone/dea_model_spec.json", 
+        "filename": "/home/jzuhone/dea_model_spec_hrc2.json", 
         "plot_names": [
             "1deamzt data__time", 
+            "1deamzt resid__data", 
             "1deamzt resid__time", 
-            "1deamzt resid__data"
+            "roll data__time"
         ], 
         "set_data_vals": {}, 
         "size": [
-            1827, 
-            1124
+            1818, 
+            1056
         ]
     }, 
     "mval_names": [], 
-    "name": "dea_state", 
+    "name": "1deamzt", 
     "pars": [
         {
             "comp_name": "mask__1deamzt_gt", 
@@ -244,7 +245,7 @@
             "max": 2.0, 
             "min": -0.11139300563792043, 
             "name": "P_45", 
-            "val": 0.11950129572145077
+            "val": 0.18494201911141472
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
@@ -254,7 +255,7 @@
             "max": 2.0, 
             "min": -0.3441833953547427, 
             "name": "P_60", 
-            "val": 0.34781581740414846
+            "val": 0.38034681993285241
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
@@ -264,7 +265,7 @@
             "max": 2.0, 
             "min": -0.04055563694127384, 
             "name": "P_90", 
-            "val": 0.52978475174985917
+            "val": 0.48537891995117005
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
@@ -274,7 +275,7 @@
             "max": 2.0, 
             "min": 0.0, 
             "name": "P_110", 
-            "val": 1.2350525841165401
+            "val": 1.2018687887787036
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
@@ -284,7 +285,7 @@
             "max": 2.0, 
             "min": 0.0, 
             "name": "P_130", 
-            "val": 1.696627548133558
+            "val": 1.7174498984232451
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
@@ -294,7 +295,7 @@
             "max": 2.0, 
             "min": 0.0, 
             "name": "P_140", 
-            "val": 1.8546229329934603
+            "val": 1.8764765316297536
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
@@ -304,7 +305,7 @@
             "max": 2.0, 
             "min": 0.0, 
             "name": "P_150", 
-            "val": 1.9470700383014485
+            "val": 1.9751590745271215
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
@@ -314,7 +315,7 @@
             "max": 2.039721551185886, 
             "min": 0.0, 
             "name": "P_160", 
-            "val": 1.96537412253601
+            "val": 2.0110862630413413
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
@@ -324,7 +325,7 @@
             "max": 2.351249059942064, 
             "min": 0.0, 
             "name": "P_180", 
-            "val": 1.9628067089898074
+            "val": 1.9214350028035585
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
@@ -332,9 +333,9 @@
             "frozen": true, 
             "full_name": "solarheat__1deamzt__dP_45", 
             "max": 1.0, 
-            "min": -1.0, 
+            "min": 0.0, 
             "name": "dP_45", 
-            "val": -0.11017121309785832
+            "val": 0.25218295436348148
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
@@ -342,9 +343,9 @@
             "frozen": true, 
             "full_name": "solarheat__1deamzt__dP_60", 
             "max": 1.0, 
-            "min": -1.0, 
+            "min": 0.0, 
             "name": "dP_60", 
-            "val": 0.063019659636453715
+            "val": 0.032780483209189873
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
@@ -352,9 +353,9 @@
             "frozen": true, 
             "full_name": "solarheat__1deamzt__dP_90", 
             "max": 1.0, 
-            "min": -1.0, 
+            "min": 0.0, 
             "name": "dP_90", 
-            "val": -0.34859075763380831
+            "val": 0.0046603277555522099
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
@@ -362,9 +363,9 @@
             "frozen": true, 
             "full_name": "solarheat__1deamzt__dP_110", 
             "max": 1.0, 
-            "min": -1.0, 
+            "min": 0.0, 
             "name": "dP_110", 
-            "val": 0.34297599116523714
+            "val": 0.012857935808555383
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
@@ -372,9 +373,9 @@
             "frozen": true, 
             "full_name": "solarheat__1deamzt__dP_130", 
             "max": 1.0, 
-            "min": -1.0, 
+            "min": 0.0, 
             "name": "dP_130", 
-            "val": 0.10716675266864889
+            "val": 0.24965995961067622
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
@@ -382,9 +383,9 @@
             "frozen": true, 
             "full_name": "solarheat__1deamzt__dP_140", 
             "max": 1.0, 
-            "min": -1.0, 
+            "min": 0.0, 
             "name": "dP_140", 
-            "val": 0.10229742197636718
+            "val": 0.16071353222820717
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
@@ -392,9 +393,9 @@
             "frozen": true, 
             "full_name": "solarheat__1deamzt__dP_150", 
             "max": 1.0, 
-            "min": -1.0, 
+            "min": 0.0, 
             "name": "dP_150", 
-            "val": 0.24619298490615155
+            "val": 0.22599069991487863
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
@@ -402,19 +403,19 @@
             "frozen": true, 
             "full_name": "solarheat__1deamzt__dP_160", 
             "max": 1.0, 
-            "min": -1.0, 
+            "min": 0.0, 
             "name": "dP_160", 
-            "val": 0.29716232303036894
+            "val": 0.26306189938993163
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
             "fmt": "{:.4g}", 
             "frozen": true, 
             "full_name": "solarheat__1deamzt__dP_180", 
-            "max": 1.0, 
-            "min": -1.0, 
+            "max": 2.0, 
+            "min": 0.0, 
             "name": "dP_180", 
-            "val": 0.50042225518252725
+            "val": 0.88403906654950615
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
@@ -424,7 +425,7 @@
             "max": 3000.0, 
             "min": 1000.0, 
             "name": "tau", 
-            "val": 1279.5046454248154
+            "val": 1279.4182240167634
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
@@ -434,7 +435,7 @@
             "max": 1.0, 
             "min": -1.0, 
             "name": "ampl", 
-            "val": 0.052467475913896382
+            "val": 0.054166286294288754
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
@@ -450,21 +451,31 @@
             "comp_name": "solarheat__1deamzt", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "solarheat__1deamzt__hrc_bias", 
+            "full_name": "solarheat__1deamzt__hrci_bias", 
             "max": 10.0, 
             "min": -10.0, 
-            "name": "hrc_bias", 
-            "val": -0.060292967101965599
+            "name": "hrci_bias", 
+            "val": -0.0094290344865395597
+        }, 
+        {
+            "comp_name": "solarheat__1deamzt", 
+            "fmt": "{:.4g}", 
+            "frozen": true, 
+            "full_name": "solarheat__1deamzt__hrcs_bias", 
+            "max": 10.0, 
+            "min": -10.0, 
+            "name": "hrcs_bias", 
+            "val": -0.071336886205177807
         }, 
         {
             "comp_name": "solarheat_off_nom_roll__1deamzt", 
             "fmt": "{:.4g}", 
-            "frozen": true, 
+            "frozen": false, 
             "full_name": "solarheat_off_nom_roll__1deamzt__P_plus_y", 
             "max": 5.0, 
             "min": -5.0, 
             "name": "P_plus_y", 
-            "val": -0.55326235433760229
+            "val": -0.47184869289895925
         }, 
         {
             "comp_name": "solarheat_off_nom_roll__1deamzt", 
@@ -474,27 +485,27 @@
             "max": 5.0, 
             "min": -5.0, 
             "name": "P_minus_y", 
-            "val": -0.86135043361167751
+            "val": -1.0443368692192223
         }, 
         {
             "comp_name": "heatsink__1deamzt", 
             "fmt": "{:.4g}", 
-            "frozen": false, 
+            "frozen": true, 
             "full_name": "heatsink__1deamzt__P", 
             "max": 10.0, 
             "min": -10.0, 
             "name": "P", 
-            "val": -1.9976915946626255
+            "val": -1.996781893890754
         }, 
         {
             "comp_name": "heatsink__1deamzt", 
             "fmt": "{:.4g}", 
-            "frozen": false, 
+            "frozen": true, 
             "full_name": "heatsink__1deamzt__tau", 
             "max": 200.0, 
             "min": 2.0, 
             "name": "tau", 
-            "val": 27.73732703132421
+            "val": 26.686777575620017
         }, 
         {
             "comp_name": "heatsink__1deamzt", 
@@ -510,111 +521,111 @@
             "comp_name": "dpa_power", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "dpa_power__pow_0xxx", 
+            "full_name": "dpa_power__pow_00xx", 
             "max": 60, 
             "min": 10, 
-            "name": "pow_0xxx", 
-            "val": 10.380581350883318
+            "name": "pow_00xx", 
+            "val": 10.217865617708288
         }, 
         {
             "comp_name": "dpa_power", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "dpa_power__pow_1xxx", 
+            "full_name": "dpa_power__pow_x0xx", 
+            "max": 60, 
+            "min": 10, 
+            "name": "pow_x0xx", 
+            "val": 19.986615617708296
+        }, 
+        {
+            "comp_name": "dpa_power", 
+            "fmt": "{:.4g}", 
+            "frozen": true, 
+            "full_name": "dpa_power__pow_x1xx", 
             "max": 60, 
             "min": 15, 
-            "name": "pow_1xxx", 
-            "val": 19.852640719795332
+            "name": "pow_x1xx", 
+            "val": 19.324330879766414
         }, 
         {
             "comp_name": "dpa_power", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "dpa_power__pow_2xxx", 
+            "full_name": "dpa_power__pow_x2xx", 
             "max": 80, 
             "min": 20, 
-            "name": "pow_2xxx", 
-            "val": 27.639545434446816
+            "name": "pow_x2xx", 
+            "val": 27.277233087371307
         }, 
         {
             "comp_name": "dpa_power", 
             "fmt": "{:.4g}", 
-            "frozen": false, 
-            "full_name": "dpa_power__pow_3xx0", 
+            "frozen": true, 
+            "full_name": "dpa_power__pow_x3x0", 
             "max": 100, 
             "min": 20, 
-            "name": "pow_3xx0", 
-            "val": 31.408230032317274
+            "name": "pow_x3x0", 
+            "val": 22.521110847215926
         }, 
         {
             "comp_name": "dpa_power", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "dpa_power__pow_3xx1", 
+            "full_name": "dpa_power__pow_x3x1", 
             "max": 100, 
             "min": 20, 
-            "name": "pow_3xx1", 
-            "val": 36.995841085839913
+            "name": "pow_x3x1", 
+            "val": 37.533963928741031
         }, 
         {
             "comp_name": "dpa_power", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "dpa_power__pow_4xxx", 
+            "full_name": "dpa_power__pow_x4xx", 
             "max": 120, 
             "min": 20, 
-            "name": "pow_4xxx", 
-            "val": 44.922995037294932
+            "name": "pow_x4xx", 
+            "val": 45.909757536862188
         }, 
         {
             "comp_name": "dpa_power", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "dpa_power__pow_55x0", 
+            "full_name": "dpa_power__pow_x5x0", 
             "max": 120, 
             "min": 20, 
-            "name": "pow_55x0", 
-            "val": 28.688493925945245
+            "name": "pow_x5x0", 
+            "val": 28.564436864636242
         }, 
         {
             "comp_name": "dpa_power", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "dpa_power__pow_5xxx", 
+            "full_name": "dpa_power__pow_x5x1", 
             "max": 120, 
             "min": 20, 
-            "name": "pow_5xxx", 
-            "val": 53.862615033403202
+            "name": "pow_x5x1", 
+            "val": 55.272401645690806
         }, 
         {
             "comp_name": "dpa_power", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "dpa_power__pow_66x0", 
+            "full_name": "dpa_power__pow_x6x0", 
             "max": 140, 
             "min": 20, 
-            "name": "pow_66x0", 
-            "val": 31.408230032317274
+            "name": "pow_x6x0", 
+            "val": 31.608249107341187
         }, 
         {
             "comp_name": "dpa_power", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "dpa_power__pow_6611", 
+            "full_name": "dpa_power__pow_x6x1", 
             "max": 140, 
             "min": 20, 
-            "name": "pow_6611", 
-            "val": 62.177343680863189
-        }, 
-        {
-            "comp_name": "dpa_power", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "dpa_power__pow_6xxx", 
-            "max": 140, 
-            "min": 20, 
-            "name": "pow_6xxx", 
-            "val": 56.540825216349631
+            "name": "pow_x6x1", 
+            "val": 64.626698701280091
         }, 
         {
             "comp_name": "dpa_power", 
@@ -624,7 +635,7 @@
             "max": 2.0, 
             "min": 0.0, 
             "name": "mult", 
-            "val": 1.6728015712752409
+            "val": 1.6204763381868217
         }, 
         {
             "comp_name": "dpa_power", 
@@ -644,7 +655,7 @@
             "max": 2.0, 
             "min": 0.0, 
             "name": "k", 
-            "val": 0.17909760134761898
+            "val": 0.15419261871152101
         }, 
         {
             "comp_name": "prop_heat__1deamzt", 

--- a/chandra_models/xija/dea/dea_spec.json
+++ b/chandra_models/xija/dea/dea_spec.json
@@ -143,7 +143,7 @@
                     0.79
                 ], 
                 "eclipse_comp": "eclipse", 
-                "epoch": "2017:352", 
+                "epoch": "2017:365", 
                 "pitch_comp": "pitch", 
                 "simz_comp": "sim_z", 
                 "var_func": "linear"
@@ -183,11 +183,11 @@
                 "fep_count": "fep_count", 
                 "pow_states": [
                     "00xx", 
+                    "30xx", 
                     "x0xx", 
                     "x1xx", 
                     "x2xx", 
-                    "x3x0", 
-                    "x3x1", 
+                    "x3xx", 
                     "x4xx", 
                     "x5x0", 
                     "x5x1", 
@@ -207,21 +207,22 @@
             "name": "prop_heat__1deamzt"
         }
     ], 
-    "datestart": "2017:170:12:05:12.816", 
-    "datestop": "2018:169:23:50:48.816", 
+    "datestart": "2017:183:12:03:04.816", 
+    "datestop": "2018:182:23:54:08.816", 
     "dt": 328.0, 
     "gui_config": {
         "filename": "/home/jzuhone/dea_model_spec_hrc2.json", 
         "plot_names": [
             "1deamzt data__time", 
-            "1deamzt resid__data", 
             "1deamzt resid__time", 
-            "roll data__time"
+            "sim_z data__time", 
+            "vid_board data__time", 
+            "clocking data__time"
         ], 
         "set_data_vals": {}, 
         "size": [
-            1818, 
-            1056
+            1986, 
+            1217
         ]
     }, 
     "mval_names": [], 
@@ -245,7 +246,7 @@
             "max": 2.0, 
             "min": -0.11139300563792043, 
             "name": "P_45", 
-            "val": 0.18494201911141472
+            "val": 0.18755350399290041
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
@@ -255,7 +256,7 @@
             "max": 2.0, 
             "min": -0.3441833953547427, 
             "name": "P_60", 
-            "val": 0.38034681993285241
+            "val": 0.3806862787853536
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
@@ -265,7 +266,7 @@
             "max": 2.0, 
             "min": -0.04055563694127384, 
             "name": "P_90", 
-            "val": 0.48537891995117005
+            "val": 0.48542718005466162
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
@@ -275,7 +276,7 @@
             "max": 2.0, 
             "min": 0.0, 
             "name": "P_110", 
-            "val": 1.2018687887787036
+            "val": 1.2020019393520875
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
@@ -285,7 +286,7 @@
             "max": 2.0, 
             "min": 0.0, 
             "name": "P_130", 
-            "val": 1.7174498984232451
+            "val": 1.7200352563895727
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
@@ -295,7 +296,7 @@
             "max": 2.0, 
             "min": 0.0, 
             "name": "P_140", 
-            "val": 1.8764765316297536
+            "val": 1.8781408033515417
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
@@ -305,7 +306,7 @@
             "max": 2.0, 
             "min": 0.0, 
             "name": "P_150", 
-            "val": 1.9751590745271215
+            "val": 1.9774993250713095
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
@@ -315,7 +316,7 @@
             "max": 2.039721551185886, 
             "min": 0.0, 
             "name": "P_160", 
-            "val": 2.0110862630413413
+            "val": 2.0138104050234418
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
@@ -325,7 +326,7 @@
             "max": 2.351249059942064, 
             "min": 0.0, 
             "name": "P_180", 
-            "val": 1.9214350028035585
+            "val": 1.9305896844225596
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
@@ -470,7 +471,7 @@
         {
             "comp_name": "solarheat_off_nom_roll__1deamzt", 
             "fmt": "{:.4g}", 
-            "frozen": false, 
+            "frozen": true, 
             "full_name": "solarheat_off_nom_roll__1deamzt__P_plus_y", 
             "max": 5.0, 
             "min": -5.0, 
@@ -531,11 +532,21 @@
             "comp_name": "dpa_power", 
             "fmt": "{:.4g}", 
             "frozen": true, 
+            "full_name": "dpa_power__pow_30xx", 
+            "max": 60, 
+            "min": 10, 
+            "name": "pow_30xx", 
+            "val": 20.267865617708281
+        }, 
+        {
+            "comp_name": "dpa_power", 
+            "fmt": "{:.4g}", 
+            "frozen": true, 
             "full_name": "dpa_power__pow_x0xx", 
             "max": 60, 
             "min": 10, 
             "name": "pow_x0xx", 
-            "val": 19.986615617708296
+            "val": 15.561615617708288
         }, 
         {
             "comp_name": "dpa_power", 
@@ -561,21 +572,11 @@
             "comp_name": "dpa_power", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "dpa_power__pow_x3x0", 
+            "full_name": "dpa_power__pow_x3xx", 
             "max": 100, 
             "min": 20, 
-            "name": "pow_x3x0", 
-            "val": 22.521110847215926
-        }, 
-        {
-            "comp_name": "dpa_power", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "dpa_power__pow_x3x1", 
-            "max": 100, 
-            "min": 20, 
-            "name": "pow_x3x1", 
-            "val": 37.533963928741031
+            "name": "pow_x3xx", 
+            "val": 36.933963928741029
         }, 
         {
             "comp_name": "dpa_power", 

--- a/chandra_models/xija/dea/dea_spec.json
+++ b/chandra_models/xija/dea/dea_spec.json
@@ -143,7 +143,7 @@
                     0.79
                 ], 
                 "eclipse_comp": "eclipse", 
-                "epoch": "2017:365", 
+                "epoch": "2016:188", 
                 "pitch_comp": "pitch", 
                 "simz_comp": "sim_z", 
                 "var_func": "linear"
@@ -207,11 +207,11 @@
             "name": "prop_heat__1deamzt"
         }
     ], 
-    "datestart": "2017:183:12:03:04.816", 
-    "datestop": "2018:182:23:54:08.816", 
+    "datestart": "2014:188:12:05:04.816", 
+    "datestop": "2018:186:23:50:32.816", 
     "dt": 328.0, 
     "gui_config": {
-        "filename": "/home/jzuhone/dea_model_spec_hrc2.json", 
+        "filename": "/home/jzuhone/dea_spec.json", 
         "plot_names": [
             "1deamzt data__time", 
             "1deamzt resid__time", 
@@ -241,172 +241,172 @@
         {
             "comp_name": "solarheat__1deamzt", 
             "fmt": "{:.4g}", 
-            "frozen": true, 
+            "frozen": false, 
             "full_name": "solarheat__1deamzt__P_45", 
             "max": 2.0, 
             "min": -0.11139300563792043, 
             "name": "P_45", 
-            "val": 0.18755350399290041
+            "val": 0.20429347382254895
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
             "fmt": "{:.4g}", 
-            "frozen": true, 
+            "frozen": false, 
             "full_name": "solarheat__1deamzt__P_60", 
             "max": 2.0, 
             "min": -0.3441833953547427, 
             "name": "P_60", 
-            "val": 0.3806862787853536
+            "val": 0.37640404082413714
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
             "fmt": "{:.4g}", 
-            "frozen": true, 
+            "frozen": false, 
             "full_name": "solarheat__1deamzt__P_90", 
             "max": 2.0, 
             "min": -0.04055563694127384, 
             "name": "P_90", 
-            "val": 0.48542718005466162
+            "val": 0.49732642012552997
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
             "fmt": "{:.4g}", 
-            "frozen": true, 
+            "frozen": false, 
             "full_name": "solarheat__1deamzt__P_110", 
             "max": 2.0, 
             "min": 0.0, 
             "name": "P_110", 
-            "val": 1.2020019393520875
+            "val": 1.1398182837424469
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
             "fmt": "{:.4g}", 
-            "frozen": true, 
+            "frozen": false, 
             "full_name": "solarheat__1deamzt__P_130", 
             "max": 2.0, 
             "min": 0.0, 
             "name": "P_130", 
-            "val": 1.7200352563895727
+            "val": 1.6350239351798534
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
             "fmt": "{:.4g}", 
-            "frozen": true, 
+            "frozen": false, 
             "full_name": "solarheat__1deamzt__P_140", 
             "max": 2.0, 
             "min": 0.0, 
             "name": "P_140", 
-            "val": 1.8781408033515417
+            "val": 1.7913790050651217
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
             "fmt": "{:.4g}", 
-            "frozen": true, 
+            "frozen": false, 
             "full_name": "solarheat__1deamzt__P_150", 
             "max": 2.0, 
             "min": 0.0, 
             "name": "P_150", 
-            "val": 1.9774993250713095
+            "val": 1.8733102553232714
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
             "fmt": "{:.4g}", 
-            "frozen": true, 
+            "frozen": false, 
             "full_name": "solarheat__1deamzt__P_160", 
             "max": 2.039721551185886, 
             "min": 0.0, 
             "name": "P_160", 
-            "val": 2.0138104050234418
+            "val": 1.8968265549864549
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
             "fmt": "{:.4g}", 
-            "frozen": true, 
+            "frozen": false, 
             "full_name": "solarheat__1deamzt__P_180", 
             "max": 2.351249059942064, 
             "min": 0.0, 
             "name": "P_180", 
-            "val": 1.9305896844225596
+            "val": 1.6223690772098935
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
             "fmt": "{:.4g}", 
             "frozen": true, 
             "full_name": "solarheat__1deamzt__dP_45", 
-            "max": 1.0, 
-            "min": 0.0, 
+            "max": 2.0, 
+            "min": -2.0, 
             "name": "dP_45", 
-            "val": 0.25218295436348148
+            "val": -0.039897638132493293
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
             "fmt": "{:.4g}", 
             "frozen": true, 
             "full_name": "solarheat__1deamzt__dP_60", 
-            "max": 1.0, 
-            "min": 0.0, 
+            "max": 2.0, 
+            "min": -2.0, 
             "name": "dP_60", 
-            "val": 0.032780483209189873
+            "val": -0.02043969754340327
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
             "fmt": "{:.4g}", 
             "frozen": true, 
             "full_name": "solarheat__1deamzt__dP_90", 
-            "max": 1.0, 
-            "min": 0.0, 
+            "max": 2.0, 
+            "min": -2.0, 
             "name": "dP_90", 
-            "val": 0.0046603277555522099
+            "val": -0.012999168684380193
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
             "fmt": "{:.4g}", 
             "frozen": true, 
             "full_name": "solarheat__1deamzt__dP_110", 
-            "max": 1.0, 
-            "min": 0.0, 
+            "max": 2.0, 
+            "min": -2.0, 
             "name": "dP_110", 
-            "val": 0.012857935808555383
+            "val": 0.098164230734023278
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
             "fmt": "{:.4g}", 
             "frozen": true, 
             "full_name": "solarheat__1deamzt__dP_130", 
-            "max": 1.0, 
-            "min": 0.0, 
+            "max": 2.0, 
+            "min": -2.0, 
             "name": "dP_130", 
-            "val": 0.24965995961067622
+            "val": 0.23937101550555939
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
             "fmt": "{:.4g}", 
             "frozen": true, 
             "full_name": "solarheat__1deamzt__dP_140", 
-            "max": 1.0, 
-            "min": 0.0, 
+            "max": 2.0, 
+            "min": -2.0, 
             "name": "dP_140", 
-            "val": 0.16071353222820717
+            "val": 0.23226715379614377
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
             "fmt": "{:.4g}", 
             "frozen": true, 
             "full_name": "solarheat__1deamzt__dP_150", 
-            "max": 1.0, 
-            "min": 0.0, 
+            "max": 2.0, 
+            "min": -2.0, 
             "name": "dP_150", 
-            "val": 0.22599069991487863
+            "val": 0.270666967072136
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
             "fmt": "{:.4g}", 
             "frozen": true, 
             "full_name": "solarheat__1deamzt__dP_160", 
-            "max": 1.0, 
-            "min": 0.0, 
+            "max": 2.0, 
+            "min": -2.0, 
             "name": "dP_160", 
-            "val": 0.26306189938993163
+            "val": 0.24638858787820209
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
@@ -414,9 +414,9 @@
             "frozen": true, 
             "full_name": "solarheat__1deamzt__dP_180", 
             "max": 2.0, 
-            "min": 0.0, 
+            "min": -2.0, 
             "name": "dP_180", 
-            "val": 0.88403906654950615
+            "val": 0.58320929296693513
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
@@ -426,7 +426,7 @@
             "max": 3000.0, 
             "min": 1000.0, 
             "name": "tau", 
-            "val": 1279.4182240167634
+            "val": 1279.9286566103506
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
@@ -436,7 +436,7 @@
             "max": 1.0, 
             "min": -1.0, 
             "name": "ampl", 
-            "val": 0.054166286294288754
+            "val": 0.052316725201777894
         }, 
         {
             "comp_name": "solarheat__1deamzt", 
@@ -476,7 +476,7 @@
             "max": 5.0, 
             "min": -5.0, 
             "name": "P_plus_y", 
-            "val": -0.47184869289895925
+            "val": -0.30406106949350276
         }, 
         {
             "comp_name": "solarheat_off_nom_roll__1deamzt", 
@@ -486,7 +486,7 @@
             "max": 5.0, 
             "min": -5.0, 
             "name": "P_minus_y", 
-            "val": -1.0443368692192223
+            "val": -0.97994196603623884
         }, 
         {
             "comp_name": "heatsink__1deamzt", 
@@ -526,7 +526,7 @@
             "max": 60, 
             "min": 10, 
             "name": "pow_00xx", 
-            "val": 10.217865617708288
+            "val": 10.772892893711063
         }, 
         {
             "comp_name": "dpa_power", 
@@ -536,7 +536,7 @@
             "max": 60, 
             "min": 10, 
             "name": "pow_30xx", 
-            "val": 20.267865617708281
+            "val": 20.46294045126459
         }, 
         {
             "comp_name": "dpa_power", 
@@ -546,7 +546,7 @@
             "max": 60, 
             "min": 10, 
             "name": "pow_x0xx", 
-            "val": 15.561615617708288
+            "val": 14.211937107907737
         }, 
         {
             "comp_name": "dpa_power", 
@@ -556,7 +556,7 @@
             "max": 60, 
             "min": 15, 
             "name": "pow_x1xx", 
-            "val": 19.324330879766414
+            "val": 18.999862042996298
         }, 
         {
             "comp_name": "dpa_power", 
@@ -566,7 +566,7 @@
             "max": 80, 
             "min": 20, 
             "name": "pow_x2xx", 
-            "val": 27.277233087371307
+            "val": 27.406767774741077
         }, 
         {
             "comp_name": "dpa_power", 
@@ -576,7 +576,7 @@
             "max": 100, 
             "min": 20, 
             "name": "pow_x3xx", 
-            "val": 36.933963928741029
+            "val": 36.569757745422628
         }, 
         {
             "comp_name": "dpa_power", 
@@ -586,7 +586,7 @@
             "max": 120, 
             "min": 20, 
             "name": "pow_x4xx", 
-            "val": 45.909757536862188
+            "val": 46.037646901970803
         }, 
         {
             "comp_name": "dpa_power", 
@@ -596,7 +596,7 @@
             "max": 120, 
             "min": 20, 
             "name": "pow_x5x0", 
-            "val": 28.564436864636242
+            "val": 32.621435991807957
         }, 
         {
             "comp_name": "dpa_power", 
@@ -606,7 +606,7 @@
             "max": 120, 
             "min": 20, 
             "name": "pow_x5x1", 
-            "val": 55.272401645690806
+            "val": 54.983829833090439
         }, 
         {
             "comp_name": "dpa_power", 
@@ -616,7 +616,7 @@
             "max": 140, 
             "min": 20, 
             "name": "pow_x6x0", 
-            "val": 31.608249107341187
+            "val": 32.280246493771052
         }, 
         {
             "comp_name": "dpa_power", 
@@ -626,7 +626,7 @@
             "max": 140, 
             "min": 20, 
             "name": "pow_x6x1", 
-            "val": 64.626698701280091
+            "val": 64.241583132852057
         }, 
         {
             "comp_name": "dpa_power", 
@@ -636,7 +636,7 @@
             "max": 2.0, 
             "min": 0.0, 
             "name": "mult", 
-            "val": 1.6204763381868217
+            "val": 1.6185494127162166
         }, 
         {
             "comp_name": "dpa_power", 
@@ -646,7 +646,7 @@
             "max": 25.0, 
             "min": 10.0, 
             "name": "bias", 
-            "val": 16.833442458970822
+            "val": 16.803663861208676
         }, 
         {
             "comp_name": "prop_heat__1deamzt", 

--- a/chandra_models/xija/dpa/dpa_spec.json
+++ b/chandra_models/xija/dpa/dpa_spec.json
@@ -55,6 +55,27 @@
             "name": "1dpamzt"
         }, 
         {
+            "class_name": "Node", 
+            "init_args": [
+                "dpa0"
+            ], 
+            "init_kwargs": {
+                "sigma": 100000.0
+            }, 
+            "name": "dpa0"
+        }, 
+        {
+            "class_name": "Coupling", 
+            "init_args": [
+                "1dpamzt", 
+                "dpa0"
+            ], 
+            "init_kwargs": {
+                "tau": 30.0
+            }, 
+            "name": "coupling__1dpamzt__dpa0"
+        }, 
+        {
             "class_name": "SimZ", 
             "init_args": [], 
             "init_kwargs": {}, 
@@ -111,9 +132,9 @@
             "name": "clocking"
         }, 
         {
-            "class_name": "SolarHeatHrc", 
+            "class_name": "SolarHeatHrcOpts", 
             "init_args": [
-                "1dpamzt"
+                "dpa0"
             ], 
             "init_kwargs": {
                 "P_pitches": [
@@ -126,6 +147,8 @@
                     130, 
                     140, 
                     150, 
+                    160, 
+                    170, 
                     180
                 ], 
                 "Ps": [
@@ -138,20 +161,22 @@
                     1.0, 
                     0.9, 
                     0.8, 
+                    0.8, 
+                    0.8, 
                     0.7
                 ], 
                 "eclipse_comp": "eclipse", 
-                "epoch": "2017:322", 
+                "epoch": "2017:357", 
                 "pitch_comp": "pitch", 
                 "simz_comp": "sim_z", 
                 "var_func": "linear"
             }, 
-            "name": "solarheat__1dpamzt"
+            "name": "solarheat__dpa0"
         }, 
         {
             "class_name": "SolarHeatOffNomRoll", 
             "init_args": [
-                "1dpamzt"
+                "dpa0"
             ], 
             "init_kwargs": {
                 "P_minus_y": 0.0, 
@@ -160,20 +185,20 @@
                 "pitch_comp": "pitch", 
                 "roll_comp": "roll"
             }, 
-            "name": "solarheat_off_nom_roll__1dpamzt"
+            "name": "solarheat_off_nom_roll__dpa0"
         }, 
         {
             "class_name": "HeatSinkRef", 
             "init_args": [
-                "1dpamzt"
+                "dpa0"
             ], 
             "init_kwargs": {}, 
-            "name": "heatsink__1dpamzt"
+            "name": "heatsink__dpa0"
         }, 
         {
             "class_name": "AcisDpaStatePower", 
             "init_args": [
-                "1dpamzt"
+                "dpa0"
             ], 
             "init_kwargs": {
                 "ccd_count": "ccd_count", 
@@ -186,11 +211,10 @@
                     "3xx0", 
                     "3xx1", 
                     "4xxx", 
-                    "55x0", 
-                    "5xxx", 
-                    "66x0", 
-                    "6611", 
-                    "6xxx"
+                    "5xx0", 
+                    "5xx1", 
+                    "6xx0", 
+                    "6xx1"
                 ], 
                 "vid_board": "vid_board"
             }, 
@@ -199,23 +223,25 @@
         {
             "class_name": "PropHeater", 
             "init_args": [
-                "1dpamzt"
+                "dpa0"
             ], 
             "init_kwargs": {}, 
-            "name": "prop_heat__1dpamzt"
+            "name": "prop_heat__dpa0"
         }
     ], 
-    "datestart": "2017:272:12:03:36.816", 
-    "datestop": "2018:007:11:50:08.816", 
+    "datestart": "2017:175:12:04:48.816", 
+    "datestop": "2018:175:11:52:00.816", 
     "dt": 328.0, 
     "gui_config": {
-        "filename": "/home/gregg/xija/JAN_08_Tweaked_Secular_3xx0_55x0_eq_52_6611_eq_83.16.json", 
+        "filename": "/home/gregg/THERMAL-MODELS/dpa_check/dpa_check/June_27A_Delay_Start.json", 
         "plot_names": [
             "1dpamzt data__time", 
-            "fep_count data__time", 
-            "1dpamzt resid__time"
+            "1dpamzt resid__time", 
+            "fep_count data__time"
         ], 
-        "set_data_vals": {}, 
+        "set_data_vals": {
+            "dpa0": 20
+        }, 
         "size": [
             1703, 
             1028
@@ -235,294 +261,354 @@
             "val": 10.0
         }, 
         {
-            "comp_name": "solarheat__1dpamzt", 
+            "comp_name": "coupling__1dpamzt__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "solarheat__1dpamzt__P_45", 
+            "full_name": "coupling__1dpamzt__dpa0__tau", 
+            "max": 200.0, 
+            "min": 0.01, 
+            "name": "tau", 
+            "val": 1.3125
+        }, 
+        {
+            "comp_name": "solarheat__dpa0", 
+            "fmt": "{:.4g}", 
+            "frozen": true, 
+            "full_name": "solarheat__dpa0__P_45", 
             "max": 2.0, 
             "min": 0.0, 
             "name": "P_45", 
-            "val": 0.327587768280721
+            "val": 0.30929532386219027
         }, 
         {
-            "comp_name": "solarheat__1dpamzt", 
+            "comp_name": "solarheat__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "solarheat__1dpamzt__P_60", 
+            "full_name": "solarheat__dpa0__P_60", 
             "max": 2.0, 
             "min": 0.0, 
             "name": "P_60", 
-            "val": 0.50691536564681283
+            "val": 0.49734629508228301
         }, 
         {
-            "comp_name": "solarheat__1dpamzt", 
+            "comp_name": "solarheat__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "solarheat__1dpamzt__P_90", 
+            "full_name": "solarheat__dpa0__P_90", 
             "max": 2.0, 
             "min": 0.0, 
             "name": "P_90", 
-            "val": 0.65278948587181806
+            "val": 0.64185611343020099
         }, 
         {
-            "comp_name": "solarheat__1dpamzt", 
+            "comp_name": "solarheat__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "solarheat__1dpamzt__P_105", 
+            "full_name": "solarheat__dpa0__P_105", 
             "max": 2.0, 
             "min": 0.0, 
             "name": "P_105", 
-            "val": 1.0458399832631315
+            "val": 1.0462762400681505
         }, 
         {
-            "comp_name": "solarheat__1dpamzt", 
+            "comp_name": "solarheat__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "solarheat__1dpamzt__P_115", 
+            "full_name": "solarheat__dpa0__P_115", 
             "max": 2.0, 
             "min": 0.0, 
             "name": "P_115", 
-            "val": 1.4577180298448442
+            "val": 1.4412243426561426
         }, 
         {
-            "comp_name": "solarheat__1dpamzt", 
+            "comp_name": "solarheat__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "solarheat__1dpamzt__P_125", 
+            "full_name": "solarheat__dpa0__P_125", 
             "max": 2.0, 
             "min": 0.0, 
             "name": "P_125", 
-            "val": 1.6220613701704625
+            "val": 1.6296652895085038
         }, 
         {
-            "comp_name": "solarheat__1dpamzt", 
+            "comp_name": "solarheat__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "solarheat__1dpamzt__P_130", 
+            "full_name": "solarheat__dpa0__P_130", 
             "max": 2.0, 
             "min": 0.0, 
             "name": "P_130", 
-            "val": 1.76337047173646
+            "val": 1.7683251241858977
         }, 
         {
-            "comp_name": "solarheat__1dpamzt", 
+            "comp_name": "solarheat__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "solarheat__1dpamzt__P_140", 
+            "full_name": "solarheat__dpa0__P_140", 
             "max": 2.114, 
             "min": 0.0, 
             "name": "P_140", 
-            "val": 1.9519176394735367
+            "val": 1.9415305962855411
         }, 
         {
-            "comp_name": "solarheat__1dpamzt", 
+            "comp_name": "solarheat__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "solarheat__1dpamzt__P_150", 
-            "max": 2.0136579807938038, 
+            "full_name": "solarheat__dpa0__P_150", 
+            "max": 3.015143558247852, 
             "min": 0.0, 
             "name": "P_150", 
-            "val": 2.0079476896314135
+            "val": 2.024557640045539
         }, 
         {
-            "comp_name": "solarheat__1dpamzt", 
+            "comp_name": "solarheat__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "solarheat__1dpamzt__P_180", 
+            "full_name": "solarheat__dpa0__P_160", 
+            "max": 3.015143558247852, 
+            "min": 0.0, 
+            "name": "P_160", 
+            "val": 2.0164600000242627
+        }, 
+        {
+            "comp_name": "solarheat__dpa0", 
+            "fmt": "{:.4g}", 
+            "frozen": true, 
+            "full_name": "solarheat__dpa0__P_170", 
+            "max": 3.015143558247852, 
+            "min": 0.0, 
+            "name": "P_170", 
+            "val": 2.0148972792252335
+        }, 
+        {
+            "comp_name": "solarheat__dpa0", 
+            "fmt": "{:.4g}", 
+            "frozen": true, 
+            "full_name": "solarheat__dpa0__P_180", 
             "max": 2.0, 
             "min": 0.0, 
             "name": "P_180", 
-            "val": 1.9064118239156627
+            "val": 1.8335751293230453
         }, 
         {
-            "comp_name": "solarheat__1dpamzt", 
+            "comp_name": "solarheat__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "solarheat__1dpamzt__dP_45", 
+            "full_name": "solarheat__dpa0__dP_45", 
             "max": 1.0, 
-            "min": -1.0, 
+            "min": 0.0, 
             "name": "dP_45", 
-            "val": -0.20468427918938972
+            "val": 0.0012286720429483628
         }, 
         {
-            "comp_name": "solarheat__1dpamzt", 
+            "comp_name": "solarheat__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "solarheat__1dpamzt__dP_60", 
+            "full_name": "solarheat__dpa0__dP_60", 
             "max": 1.0, 
-            "min": -1.0, 
+            "min": 0.0, 
             "name": "dP_60", 
-            "val": 0.02932516470207419
+            "val": 0.0039901314135895542
         }, 
         {
-            "comp_name": "solarheat__1dpamzt", 
+            "comp_name": "solarheat__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "solarheat__1dpamzt__dP_90", 
+            "full_name": "solarheat__dpa0__dP_90", 
             "max": 1.0, 
-            "min": -1.0, 
+            "min": 0.0, 
             "name": "dP_90", 
-            "val": 0.09882807215911346
+            "val": 0.0014844992719995837
         }, 
         {
-            "comp_name": "solarheat__1dpamzt", 
+            "comp_name": "solarheat__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "solarheat__1dpamzt__dP_105", 
+            "full_name": "solarheat__dpa0__dP_105", 
             "max": 1.0, 
-            "min": -1.0, 
+            "min": 0.0, 
             "name": "dP_105", 
-            "val": 0.0351562639363239
+            "val": 0.23714353688405265
         }, 
         {
-            "comp_name": "solarheat__1dpamzt", 
+            "comp_name": "solarheat__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "solarheat__1dpamzt__dP_115", 
+            "full_name": "solarheat__dpa0__dP_115", 
             "max": 1.0, 
-            "min": -1.0, 
+            "min": 0.0, 
             "name": "dP_115", 
-            "val": 0.058844389546675466
+            "val": 0.0032127355060925697
         }, 
         {
-            "comp_name": "solarheat__1dpamzt", 
+            "comp_name": "solarheat__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "solarheat__1dpamzt__dP_125", 
+            "full_name": "solarheat__dpa0__dP_125", 
             "max": 1.0, 
-            "min": -1.0, 
+            "min": 0.0, 
             "name": "dP_125", 
-            "val": 0.0351562639363239
+            "val": 0.18340751098560651
         }, 
         {
-            "comp_name": "solarheat__1dpamzt", 
+            "comp_name": "solarheat__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "solarheat__1dpamzt__dP_130", 
+            "full_name": "solarheat__dpa0__dP_130", 
             "max": 1.0, 
-            "min": -1.0, 
+            "min": 0.0, 
             "name": "dP_130", 
-            "val": 0.20299762838972854
+            "val": 0.24743146426576731
         }, 
         {
-            "comp_name": "solarheat__1dpamzt", 
+            "comp_name": "solarheat__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "solarheat__1dpamzt__dP_140", 
+            "full_name": "solarheat__dpa0__dP_140", 
             "max": 1.0, 
-            "min": -1.0, 
+            "min": 0.0, 
             "name": "dP_140", 
-            "val": 0.014620612573331105
+            "val": 0.25
         }, 
         {
-            "comp_name": "solarheat__1dpamzt", 
+            "comp_name": "solarheat__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "solarheat__1dpamzt__dP_150", 
+            "full_name": "solarheat__dpa0__dP_150", 
             "max": 1.0, 
-            "min": -1.0, 
+            "min": 0.0, 
             "name": "dP_150", 
-            "val": 0.36556641827690867
+            "val": 0.20494192038409578
         }, 
         {
-            "comp_name": "solarheat__1dpamzt", 
+            "comp_name": "solarheat__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "solarheat__1dpamzt__dP_180", 
+            "full_name": "solarheat__dpa0__dP_160", 
             "max": 1.0, 
-            "min": -1.0, 
-            "name": "dP_180", 
-            "val": 0.05909712404953001
+            "min": 0.0, 
+            "name": "dP_160", 
+            "val": 0.16593265270015206
         }, 
         {
-            "comp_name": "solarheat__1dpamzt", 
+            "comp_name": "solarheat__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "solarheat__1dpamzt__tau", 
+            "full_name": "solarheat__dpa0__dP_170", 
+            "max": 1.0, 
+            "min": 0.0, 
+            "name": "dP_170", 
+            "val": 0.007306231100556209
+        }, 
+        {
+            "comp_name": "solarheat__dpa0", 
+            "fmt": "{:.4g}", 
+            "frozen": true, 
+            "full_name": "solarheat__dpa0__dP_180", 
+            "max": 1.0, 
+            "min": 0.0, 
+            "name": "dP_180", 
+            "val": 0.30129939383425419
+        }, 
+        {
+            "comp_name": "solarheat__dpa0", 
+            "fmt": "{:.4g}", 
+            "frozen": true, 
+            "full_name": "solarheat__dpa0__tau", 
             "max": 3000.0, 
             "min": 1000.0, 
             "name": "tau", 
             "val": 1269.8035520969406
         }, 
         {
-            "comp_name": "solarheat__1dpamzt", 
+            "comp_name": "solarheat__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "solarheat__1dpamzt__ampl", 
+            "full_name": "solarheat__dpa0__ampl", 
             "max": 1.0, 
             "min": -1.0, 
             "name": "ampl", 
             "val": 0.046427256777960654
         }, 
         {
-            "comp_name": "solarheat__1dpamzt", 
+            "comp_name": "solarheat__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "solarheat__1dpamzt__bias", 
+            "full_name": "solarheat__dpa0__bias", 
             "max": 1.0, 
             "min": -1.0, 
             "name": "bias", 
             "val": -0.022005431182122764
         }, 
         {
-            "comp_name": "solarheat__1dpamzt", 
+            "comp_name": "solarheat__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "solarheat__1dpamzt__hrc_bias", 
+            "full_name": "solarheat__dpa0__hrci_bias", 
             "max": 1.0, 
             "min": -1.0, 
-            "name": "hrc_bias", 
-            "val": -0.08850072080437976
+            "name": "hrci_bias", 
+            "val": -0.031240811843720816
         }, 
         {
-            "comp_name": "solarheat_off_nom_roll", 
+            "comp_name": "solarheat__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "solarheat_off_nom_roll__P_plus_y", 
+            "full_name": "solarheat__dpa0__hrcs_bias", 
+            "max": 1.0, 
+            "min": -1.0, 
+            "name": "hrcs_bias", 
+            "val": -0.082288087089209455
+        }, 
+        {
+            "comp_name": "solarheat_off_nom_roll__dpa0", 
+            "fmt": "{:.4g}", 
+            "frozen": true, 
+            "full_name": "solarheat_off_nom_roll__dpa0__P_plus_y", 
             "max": 5.0, 
             "min": -5.0, 
             "name": "P_plus_y", 
-            "val": 1.3
+            "val": 1.2991132666444623
         }, 
         {
-            "comp_name": "solarheat_off_nom_roll", 
+            "comp_name": "solarheat_off_nom_roll__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "solarheat_off_nom_roll__P_minus_y", 
+            "full_name": "solarheat_off_nom_roll__dpa0__P_minus_y", 
             "max": 5.0, 
             "min": -5.0, 
             "name": "P_minus_y", 
-            "val": 0.3
+            "val": 0.56353948639606088
         }, 
         {
-            "comp_name": "heatsink__1dpamzt", 
+            "comp_name": "heatsink__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "heatsink__1dpamzt__P", 
+            "full_name": "heatsink__dpa0__P", 
             "max": 10.0, 
             "min": -10.0, 
             "name": "P", 
-            "val": -2.377751557364746
+            "val": -2.4700684483830861
         }, 
         {
-            "comp_name": "heatsink__1dpamzt", 
+            "comp_name": "heatsink__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "heatsink__1dpamzt__tau", 
+            "full_name": "heatsink__dpa0__tau", 
             "max": 200.0, 
             "min": 2.0, 
             "name": "tau", 
-            "val": 24.749591590528688
+            "val": 24.343187767342535
         }, 
         {
-            "comp_name": "heatsink__1dpamzt", 
+            "comp_name": "heatsink__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "heatsink__1dpamzt__T_ref", 
+            "full_name": "heatsink__dpa0__T_ref", 
             "max": 100, 
             "min": -100, 
             "name": "T_ref", 
-            "val": 19.36156808627122
+            "val": 21.10861225721419
         }, 
         {
             "comp_name": "dpa_power", 
@@ -532,7 +618,7 @@
             "max": 60, 
             "min": 10, 
             "name": "pow_0xxx", 
-            "val": 12.013499335555018
+            "val": 12.269192065321814
         }, 
         {
             "comp_name": "dpa_power", 
@@ -542,7 +628,7 @@
             "max": 60, 
             "min": 15, 
             "name": "pow_1xxx", 
-            "val": 24.886931775802445
+            "val": 28.144023418288651
         }, 
         {
             "comp_name": "dpa_power", 
@@ -552,7 +638,7 @@
             "max": 80, 
             "min": 20, 
             "name": "pow_2xxx", 
-            "val": 33.79737205888341
+            "val": 38.361188550271891
         }, 
         {
             "comp_name": "dpa_power", 
@@ -562,7 +648,7 @@
             "max": 100, 
             "min": 20, 
             "name": "pow_3xx0", 
-            "val": 48.87
+            "val": 40.291991910003745
         }, 
         {
             "comp_name": "dpa_power", 
@@ -572,7 +658,7 @@
             "max": 100, 
             "min": 20, 
             "name": "pow_3xx1", 
-            "val": 48.874228334449356
+            "val": 49.656751543209872
         }, 
         {
             "comp_name": "dpa_power", 
@@ -582,57 +668,47 @@
             "max": 120, 
             "min": 20, 
             "name": "pow_4xxx", 
-            "val": 59.473684210526315
+            "val": 59.39393939393939
         }, 
         {
             "comp_name": "dpa_power", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "dpa_power__pow_55x0", 
+            "full_name": "dpa_power__pow_5xx0", 
             "max": 120, 
             "min": 20, 
             "name": "pow_55x0", 
-            "val": 52.0
+            "val": 55.885096802926022
         }, 
         {
             "comp_name": "dpa_power", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "dpa_power__pow_5xxx", 
+            "full_name": "dpa_power__pow_5xx1", 
             "max": 120, 
             "min": 20, 
             "name": "pow_5xxx", 
-            "val": 65.84274749755124
+            "val": 68.48484848484848
         }, 
         {
             "comp_name": "dpa_power", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "dpa_power__pow_66x0", 
+            "full_name": "dpa_power__pow_6xx0", 
             "max": 140, 
             "min": 20, 
-            "name": "pow_66x0", 
-            "val": 61.73163047104799
+            "name": "pow_6xx0", 
+            "val": 62.087539138316231
         }, 
         {
             "comp_name": "dpa_power", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "dpa_power__pow_6611", 
+            "full_name": "dpa_power__pow_6xx1", 
             "max": 140, 
             "min": 20, 
-            "name": "pow_6611", 
-            "val": 83.15789473684211
-        }, 
-        {
-            "comp_name": "dpa_power", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "dpa_power__pow_6xxx", 
-            "max": 140, 
-            "min": 20, 
-            "name": "pow_6xxx", 
-            "val": 78.21954023381123
+            "name": "pow_6xx1", 
+            "val": 78.563925035214567
         }, 
         {
             "comp_name": "dpa_power", 
@@ -642,7 +718,7 @@
             "max": 2.0, 
             "min": 0.0, 
             "name": "mult", 
-            "val": 1.8152421598951174
+            "val": 1.8317188058387148
         }, 
         {
             "comp_name": "dpa_power", 
@@ -652,27 +728,27 @@
             "max": 100, 
             "min": 0.0, 
             "name": "bias", 
-            "val": 0.05231746528297662
+            "val": 0.47638741526752698
         }, 
         {
-            "comp_name": "prop_heat__1dpamzt", 
+            "comp_name": "prop_heat__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "prop_heat__1dpamzt__k", 
+            "full_name": "prop_heat__dpa0__k", 
             "max": 2.0, 
             "min": 0.0, 
             "name": "k", 
-            "val": 0.18302534088641037
+            "val": 0.26945112213641037
         }, 
         {
-            "comp_name": "prop_heat__1dpamzt", 
+            "comp_name": "prop_heat__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "prop_heat__1dpamzt__T_set", 
+            "full_name": "prop_heat__dpa0__T_set", 
             "max": 100.0, 
             "min": -50.0, 
             "name": "T_set", 
-            "val": 14.01383767718995
+            "val": 12.951093536564954
         }
     ], 
     "tlm_code": null

--- a/chandra_models/xija/dpa/dpa_spec.json
+++ b/chandra_models/xija/dpa/dpa_spec.json
@@ -166,7 +166,7 @@
                     0.7
                 ], 
                 "eclipse_comp": "eclipse", 
-                "epoch": "2017:357", 
+                "epoch": "2018:003", 
                 "pitch_comp": "pitch", 
                 "simz_comp": "sim_z", 
                 "var_func": "linear"
@@ -229,15 +229,16 @@
             "name": "prop_heat__dpa0"
         }
     ], 
-    "datestart": "2017:175:12:04:48.816", 
-    "datestop": "2018:175:11:52:00.816", 
+    "datestart": "2017:186:12:01:44.816", 
+    "datestop": "2018:186:11:54:24.816", 
     "dt": 328.0, 
     "gui_config": {
-        "filename": "/home/gregg/THERMAL-MODELS/dpa_check/dpa_check/June_27A_Delay_Start.json", 
+        "filename": "/home/gregg/THERMAL-MODELS/dpa_check/dpa_check/July_9A_Step_6.json", 
         "plot_names": [
             "1dpamzt data__time", 
             "1dpamzt resid__time", 
-            "fep_count data__time"
+            "fep_count data__time", 
+            "solarheat__dpa0 solar_heat__pitch"
         ], 
         "set_data_vals": {
             "dpa0": 20
@@ -278,7 +279,7 @@
             "max": 2.0, 
             "min": 0.0, 
             "name": "P_45", 
-            "val": 0.30929532386219027
+            "val": 0.3093064500639312
         }, 
         {
             "comp_name": "solarheat__dpa0", 
@@ -288,7 +289,7 @@
             "max": 2.0, 
             "min": 0.0, 
             "name": "P_60", 
-            "val": 0.49734629508228301
+            "val": 0.497382427594075
         }, 
         {
             "comp_name": "solarheat__dpa0", 
@@ -298,7 +299,7 @@
             "max": 2.0, 
             "min": 0.0, 
             "name": "P_90", 
-            "val": 0.64185611343020099
+            "val": 0.6418695562675141
         }, 
         {
             "comp_name": "solarheat__dpa0", 
@@ -308,7 +309,7 @@
             "max": 2.0, 
             "min": 0.0, 
             "name": "P_105", 
-            "val": 1.0462762400681505
+            "val": 1.048
         }, 
         {
             "comp_name": "solarheat__dpa0", 
@@ -318,7 +319,7 @@
             "max": 2.0, 
             "min": 0.0, 
             "name": "P_115", 
-            "val": 1.4412243426561426
+            "val": 1.36
         }, 
         {
             "comp_name": "solarheat__dpa0", 
@@ -328,7 +329,7 @@
             "max": 2.0, 
             "min": 0.0, 
             "name": "P_125", 
-            "val": 1.6296652895085038
+            "val": 1.6313261305602202
         }, 
         {
             "comp_name": "solarheat__dpa0", 
@@ -338,7 +339,7 @@
             "max": 2.0, 
             "min": 0.0, 
             "name": "P_130", 
-            "val": 1.7683251241858977
+            "val": 1.7705657321693469
         }, 
         {
             "comp_name": "solarheat__dpa0", 
@@ -348,7 +349,7 @@
             "max": 2.114, 
             "min": 0.0, 
             "name": "P_140", 
-            "val": 1.9415305962855411
+            "val": 1.9437944635650097
         }, 
         {
             "comp_name": "solarheat__dpa0", 
@@ -358,7 +359,7 @@
             "max": 3.015143558247852, 
             "min": 0.0, 
             "name": "P_150", 
-            "val": 2.024557640045539
+            "val": 2.026413485276535
         }, 
         {
             "comp_name": "solarheat__dpa0", 
@@ -368,7 +369,7 @@
             "max": 3.015143558247852, 
             "min": 0.0, 
             "name": "P_160", 
-            "val": 2.0164600000242627
+            "val": 2.017962598036436
         }, 
         {
             "comp_name": "solarheat__dpa0", 
@@ -378,7 +379,7 @@
             "max": 3.015143558247852, 
             "min": 0.0, 
             "name": "P_170", 
-            "val": 2.0148972792252335
+            "val": 1.95
         }, 
         {
             "comp_name": "solarheat__dpa0", 
@@ -388,7 +389,7 @@
             "max": 2.0, 
             "min": 0.0, 
             "name": "P_180", 
-            "val": 1.8335751293230453
+            "val": 1.8363035366791458
         }, 
         {
             "comp_name": "solarheat__dpa0", 
@@ -408,7 +409,7 @@
             "max": 1.0, 
             "min": 0.0, 
             "name": "dP_60", 
-            "val": 0.0039901314135895542
+            "val": 0.003990131413589554
         }, 
         {
             "comp_name": "solarheat__dpa0", 
@@ -438,7 +439,7 @@
             "max": 1.0, 
             "min": 0.0, 
             "name": "dP_115", 
-            "val": 0.0032127355060925697
+            "val": 0.3032127355060925
         }, 
         {
             "comp_name": "solarheat__dpa0", 
@@ -448,7 +449,7 @@
             "max": 1.0, 
             "min": 0.0, 
             "name": "dP_125", 
-            "val": 0.18340751098560651
+            "val": 0.1834075109856065
         }, 
         {
             "comp_name": "solarheat__dpa0", 
@@ -498,7 +499,7 @@
             "max": 1.0, 
             "min": 0.0, 
             "name": "dP_170", 
-            "val": 0.007306231100556209
+            "val": 0.2147
         }, 
         {
             "comp_name": "solarheat__dpa0", 
@@ -508,7 +509,7 @@
             "max": 1.0, 
             "min": 0.0, 
             "name": "dP_180", 
-            "val": 0.30129939383425419
+            "val": 0.3012993938342542
         }, 
         {
             "comp_name": "solarheat__dpa0", 
@@ -558,7 +559,7 @@
             "max": 1.0, 
             "min": -1.0, 
             "name": "hrcs_bias", 
-            "val": -0.082288087089209455
+            "val": -0.08228808708920946
         }, 
         {
             "comp_name": "solarheat_off_nom_roll__dpa0", 
@@ -578,7 +579,7 @@
             "max": 5.0, 
             "min": -5.0, 
             "name": "P_minus_y", 
-            "val": 0.56353948639606088
+            "val": 0.5635394863960609
         }, 
         {
             "comp_name": "heatsink__dpa0", 
@@ -588,7 +589,7 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P", 
-            "val": -2.4700684483830861
+            "val": -2.470068448383086
         }, 
         {
             "comp_name": "heatsink__dpa0", 
@@ -628,7 +629,7 @@
             "max": 60, 
             "min": 15, 
             "name": "pow_1xxx", 
-            "val": 28.144023418288651
+            "val": 28.14402341828865
         }, 
         {
             "comp_name": "dpa_power", 
@@ -638,7 +639,7 @@
             "max": 80, 
             "min": 20, 
             "name": "pow_2xxx", 
-            "val": 38.361188550271891
+            "val": 38.36118855027189
         }, 
         {
             "comp_name": "dpa_power", 
@@ -658,7 +659,7 @@
             "max": 100, 
             "min": 20, 
             "name": "pow_3xx1", 
-            "val": 49.656751543209872
+            "val": 49.65675154320987
         }, 
         {
             "comp_name": "dpa_power", 
@@ -678,7 +679,7 @@
             "max": 120, 
             "min": 20, 
             "name": "pow_55x0", 
-            "val": 55.885096802926022
+            "val": 55.88509680292602
         }, 
         {
             "comp_name": "dpa_power", 
@@ -698,7 +699,7 @@
             "max": 140, 
             "min": 20, 
             "name": "pow_6xx0", 
-            "val": 62.087539138316231
+            "val": 62.08753913831623
         }, 
         {
             "comp_name": "dpa_power", 
@@ -708,7 +709,7 @@
             "max": 140, 
             "min": 20, 
             "name": "pow_6xx1", 
-            "val": 78.563925035214567
+            "val": 78.56392503521457
         }, 
         {
             "comp_name": "dpa_power", 
@@ -728,7 +729,7 @@
             "max": 100, 
             "min": 0.0, 
             "name": "bias", 
-            "val": 0.47638741526752698
+            "val": 0.476387415267527
         }, 
         {
             "comp_name": "prop_heat__dpa0", 

--- a/chandra_models/xija/psmc/psmc_spec.json
+++ b/chandra_models/xija/psmc/psmc_spec.json
@@ -827,7 +827,7 @@
             "max": 80, 
             "min": 20, 
             "name": "pow_2xxx", 
-            "val": 47.338942639894853
+            "val": 37.73
         }, 
         {
             "comp_name": "dpa_power", 

--- a/chandra_models/xija/psmc/psmc_spec.json
+++ b/chandra_models/xija/psmc/psmc_spec.json
@@ -256,23 +256,37 @@
                 "ccd_count": "ccd_count", 
                 "clocking": "clocking", 
                 "fep_count": "fep_count", 
+                "pow_states": [
+                    "0xxx", 
+                    "1xxx", 
+                    "2xxx", 
+                    "3xx0", 
+                    "3xx1", 
+                    "4xxx", 
+                    "55x0", 
+                    "5xxx", 
+                    "66x0", 
+                    "6611", 
+                    "6xxx"
+                ], 
                 "vid_board": "vid_board"
             }, 
             "name": "dpa_power"
         }
     ], 
-    "datestart": "2016:202:12:02:24.816", 
-    "datestop": "2017:076:11:54:08.816", 
+    "datestart": "2017:036:12:02:48.816", 
+    "datestop": "2018:121:11:54:08.816", 
     "dt": 328.0, 
     "gui_config": {
         "autoscale": false, 
-        "filename": "/data/marple1/chandra/acis/thermal_models/psmc_models/2017_03_01/psmc_fitme2.json", 
+        "filename": "/data/marple1/chandra/acis/thermal_models/psmc_2018/psmc_f4.json", 
         "plot_names": [
             "1pdeaat data__time", 
             "1pdeaat resid__time", 
+            "pitch data__time", 
+            "fep_count data__time", 
             "sim_z data__time", 
             "roll data__time", 
-            "pitch data__time", 
             "1pdeaat resid__data", 
             "psmc_solarheat__pin1at solar_heat__pitch"
         ], 
@@ -318,7 +332,7 @@
         {
             "comp_name": "psmc_solarheat__pin1at", 
             "fmt": "{:.4g}", 
-            "frozen": false, 
+            "frozen": true, 
             "full_name": "psmc_solarheat__pin1at__P_hrcs_45", 
             "max": 10.0, 
             "min": -10.0, 
@@ -328,7 +342,7 @@
         {
             "comp_name": "psmc_solarheat__pin1at", 
             "fmt": "{:.4g}", 
-            "frozen": false, 
+            "frozen": true, 
             "full_name": "psmc_solarheat__pin1at__P_hrcs_55", 
             "max": 10.0, 
             "min": -10.0, 
@@ -378,22 +392,22 @@
         {
             "comp_name": "psmc_solarheat__pin1at", 
             "fmt": "{:.4g}", 
-            "frozen": false, 
+            "frozen": true, 
             "full_name": "psmc_solarheat__pin1at__P_hrcs_130", 
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_hrcs_130", 
-            "val": 2.4394676847724805
+            "val": 2.5308599472045903
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
             "fmt": "{:.4g}", 
-            "frozen": false, 
+            "frozen": true, 
             "full_name": "psmc_solarheat__pin1at__P_hrcs_170", 
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_hrcs_170", 
-            "val": 2.7652593224891655
+            "val": 3.0
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -458,7 +472,7 @@
         {
             "comp_name": "psmc_solarheat__pin1at", 
             "fmt": "{:.4g}", 
-            "frozen": false, 
+            "frozen": true, 
             "full_name": "psmc_solarheat__pin1at__P_hrci_130", 
             "max": 10.0, 
             "min": -10.0, 
@@ -468,7 +482,7 @@
         {
             "comp_name": "psmc_solarheat__pin1at", 
             "fmt": "{:.4g}", 
-            "frozen": false, 
+            "frozen": true, 
             "full_name": "psmc_solarheat__pin1at__P_hrci_170", 
             "max": 10.0, 
             "min": -10.0, 
@@ -483,7 +497,7 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_aciss_45", 
-            "val": 3.9407532133016678
+            "val": 3.6631785931313887
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -493,7 +507,7 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_aciss_55", 
-            "val": 3.4031213767102599
+            "val": 3.4245505112391523
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -523,7 +537,7 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_aciss_85", 
-            "val": 2.1464540001572416
+            "val": 2.0218470942324775
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -533,7 +547,7 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_aciss_95", 
-            "val": 1.671956386253606
+            "val": 1.5224042857748832
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -563,7 +577,7 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_acisi_45", 
-            "val": 3.7679268625745133
+            "val": 3.7825360349352621
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -573,7 +587,7 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_acisi_55", 
-            "val": 3.5714710675709331
+            "val": 3.4805538346038625
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -593,7 +607,7 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_acisi_75", 
-            "val": 2.7572010167659613
+            "val": 2.58515487978346
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -603,7 +617,7 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_acisi_85", 
-            "val": 2.1246629129450194
+            "val": 2.0617156697818553
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -613,7 +627,7 @@
             "max": 10.0, 
             "min": -10.0, 
             "name": "P_acisi_95", 
-            "val": 1.6810618207250487
+            "val": 1.4905610255937749
         }, 
         {
             "comp_name": "psmc_solarheat__pin1at", 
@@ -748,22 +762,22 @@
         {
             "comp_name": "solarheat_off_nom_roll", 
             "fmt": "{:.4g}", 
-            "frozen": false, 
+            "frozen": true, 
             "full_name": "solarheat_off_nom_roll__P_plus_y", 
             "max": 5.0, 
             "min": -5.0, 
             "name": "P_plus_y", 
-            "val": 0.34784384942788771
+            "val": 0.24526233242935019
         }, 
         {
             "comp_name": "solarheat_off_nom_roll", 
             "fmt": "{:.4g}", 
-            "frozen": false, 
+            "frozen": true, 
             "full_name": "solarheat_off_nom_roll__P_minus_y", 
             "max": 5.0, 
             "min": -5.0, 
             "name": "P_minus_y", 
-            "val": -2.5834858048564042
+            "val": -3.0
         }, 
         {
             "comp_name": "heatsink__pin1at", 
@@ -818,12 +832,12 @@
         {
             "comp_name": "dpa_power", 
             "fmt": "{:.4g}", 
-            "frozen": true, 
+            "frozen": false, 
             "full_name": "dpa_power__pow_3xx0", 
             "max": 100, 
             "min": 20, 
             "name": "pow_3xx0", 
-            "val": 43.386795335502384
+            "val": 26.586795335502437
         }, 
         {
             "comp_name": "dpa_power", 
@@ -844,6 +858,16 @@
             "min": 20, 
             "name": "pow_4xxx", 
             "val": 54.867318354150441
+        }, 
+        {
+            "comp_name": "dpa_power", 
+            "fmt": "{:.4g}", 
+            "frozen": true, 
+            "full_name": "dpa_power__pow_5xx0", 
+            "max": 120, 
+            "min": 20, 
+            "name": "pow_5xx0", 
+            "val": 44.377004637397732
         }, 
         {
             "comp_name": "dpa_power", 


### PR DESCRIPTION
This PR updates the model specifications for the 1DPAMZT, 1DEAMZT, and 1PDEAAT models. 

It has the following features:

- The 1DPAMZT and 1DEAMZT models use the new xija `SolarHeatHrcOpts` class which includes the bias parameters for HRC-S and HRC-I SIM positions.
- The state power coefficients for the 1DEAMZT and 1DPAMZT models have been refactored for simplicity and to reflect better the actual physical states of their respective electronics boxes.
- A new pseudo-node has been added to the 1DPAMZT model, which has solar heating as inputs and is coupled to 1DPAMZT. This improves the fit significantly. 
- The state power coefficients have been recalibrated for 3-FEP operation in the belts.
- `dP` parameters in `SolarHeatHrcOpts` have had their minima set to zero.
- A general recalibration of all other model parameters.