### PR TITLE
Update TCYLAFT6 model parameters, including new architecture

### DIFF
--- a/chandra_models/xija/tcylaft6/tcylaft6_fit_log.json
+++ b/chandra_models/xija/tcylaft6/tcylaft6_fit_log.json
@@ -1,275 +1,5432 @@
 [
     {
-        "coupling__tcylaft6__tcylaft6_0__tau": 145.69950031390493, 
-        "date": "2016:314:20:12:48.025", 
-        "fit_stat": 7799038.8503582375, 
-        "heatsink__tcylaft6_0__T": 7.202258699852631, 
-        "heatsink__tcylaft6_0__tau": 19.035016415258287, 
-        "method": null, 
-        "solarheat__tcylaft6_0__P_100": 2.1838378986950344, 
-        "solarheat__tcylaft6_0__P_110": 2.144604786302296, 
-        "solarheat__tcylaft6_0__P_120": 1.970065963040971, 
-        "solarheat__tcylaft6_0__P_130": 1.6078783440418365, 
-        "solarheat__tcylaft6_0__P_140": 1.2241867286557584, 
-        "solarheat__tcylaft6_0__P_150": 0.7555935830951949, 
-        "solarheat__tcylaft6_0__P_160": 0.10565686619997607, 
-        "solarheat__tcylaft6_0__P_180": 0.0, 
-        "solarheat__tcylaft6_0__P_45": 1.7472813482784069, 
-        "solarheat__tcylaft6_0__P_60": 2.0886699321070847, 
-        "solarheat__tcylaft6_0__P_80": 2.2140298941667096, 
-        "solarheat__tcylaft6_0__P_90": 2.37050012773606, 
-        "solarheat__tcylaft6_0__ampl": 0.08125105152845383, 
-        "solarheat__tcylaft6_0__bias": 0.0, 
-        "solarheat__tcylaft6_0__dP_100": 0.2, 
-        "solarheat__tcylaft6_0__dP_110": 0.16733738555674266, 
-        "solarheat__tcylaft6_0__dP_120": 0.11837692281328732, 
-        "solarheat__tcylaft6_0__dP_130": 0.11, 
-        "solarheat__tcylaft6_0__dP_140": 0.11614117573923835, 
-        "solarheat__tcylaft6_0__dP_150": 0.09141459271880145, 
-        "solarheat__tcylaft6_0__dP_160": 0.045477378820906286, 
-        "solarheat__tcylaft6_0__dP_180": 0.0, 
-        "solarheat__tcylaft6_0__dP_45": 0.03924789356239728, 
-        "solarheat__tcylaft6_0__dP_60": 0.15248924198683483, 
-        "solarheat__tcylaft6_0__dP_80": 0.2, 
-        "solarheat__tcylaft6_0__dP_90": 0.2595462502455334, 
-        "solarheat__tcylaft6_0__tau": 365.0, 
-        "solarheat_off_nom_roll__tcylaft6__P_minus_y": -0.015183175540065026, 
-        "solarheat_off_nom_roll__tcylaft6__P_plus_y": -0.013433326104032245, 
-        "tstart": "2014:300:12:02:40.816", 
-        "tstop": "2016:300:11:53:27.816"
-    }, 
+        "coupling__tcylaft6__cc0__tau": {
+            "frozen": false,
+            "max": 200.0,
+            "min": 2.0,
+            "val": 24.533938201749706
+        },
+        "date": "2018:258:11:50:08.030",
+        "final_eval_num": null,
+        "fit_stat": 2720545.063156278,
+        "heatsink__cc0__T": {
+            "frozen": false,
+            "max": 100.0,
+            "min": -300.0,
+            "val": 11.508268020529213
+        },
+        "heatsink__cc0__tau": {
+            "frozen": false,
+            "max": 400.0,
+            "min": 2.0,
+            "val": 112.84830663495943
+        },
+        "heatsink__tcylaft6__T": {
+            "frozen": false,
+            "max": 100.0,
+            "min": -300.0,
+            "val": 58.17353103583307
+        },
+        "heatsink__tcylaft6__tau": {
+            "frozen": false,
+            "max": 400.0,
+            "min": 2.0,
+            "val": 16.255880671159918
+        },
+        "method": null,
+        "solarheat__cc0__P_120": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.4084857216730321
+        },
+        "solarheat__cc0__P_130": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.27665020236599175
+        },
+        "solarheat__cc0__P_140": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.13183107469096536
+        },
+        "solarheat__cc0__P_150": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -0.0438505350042786
+        },
+        "solarheat__cc0__P_155": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -0.1225404759483533
+        },
+        "solarheat__cc0__P_160": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -0.1619005805859427
+        },
+        "solarheat__cc0__P_170": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -0.15027430296824507
+        },
+        "solarheat__cc0__P_45": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.42204722371091224
+        },
+        "solarheat__cc0__P_60": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.45715765500479716
+        },
+        "solarheat__cc0__P_75": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.4825539251511344
+        },
+        "solarheat__cc0__P_90": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.5165099830061621
+        },
+        "solarheat__cc0__ampl": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.011699525132358977
+        },
+        "solarheat__cc0__bias": {
+            "frozen": true,
+            "max": 2.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_120": {
+            "frozen": true,
+            "max": 1.0,
+            "min": 0.0,
+            "val": 0.08865025125632185
+        },
+        "solarheat__cc0__dP_130": {
+            "frozen": true,
+            "max": 1.0,
+            "min": 0.0,
+            "val": 0.10673879475908703
+        },
+        "solarheat__cc0__dP_140": {
+            "frozen": true,
+            "max": 1.0,
+            "min": 0.0,
+            "val": 0.0921033111822435
+        },
+        "solarheat__cc0__dP_150": {
+            "frozen": true,
+            "max": 1.0,
+            "min": 0.0,
+            "val": 0.1058264167640823
+        },
+        "solarheat__cc0__dP_155": {
+            "frozen": true,
+            "max": 1.0,
+            "min": 0.0,
+            "val": 0.07250815851525953
+        },
+        "solarheat__cc0__dP_160": {
+            "frozen": true,
+            "max": 1.0,
+            "min": 0.0,
+            "val": 0.13166828649687373
+        },
+        "solarheat__cc0__dP_170": {
+            "frozen": true,
+            "max": 1.0,
+            "min": 0.0,
+            "val": 0.1
+        },
+        "solarheat__cc0__dP_45": {
+            "frozen": true,
+            "max": 1.0,
+            "min": 0.0,
+            "val": 0.013215529208986417
+        },
+        "solarheat__cc0__dP_60": {
+            "frozen": true,
+            "max": 1.0,
+            "min": 0.0,
+            "val": 0.04674166653663772
+        },
+        "solarheat__cc0__dP_75": {
+            "frozen": true,
+            "max": 1.0,
+            "min": 0.0,
+            "val": 0.09909677856842877
+        },
+        "solarheat__cc0__dP_90": {
+            "frozen": true,
+            "max": 1.0,
+            "min": 0.0,
+            "val": 0.07518801749795356
+        },
+        "solarheat__cc0__tau": {
+            "frozen": true,
+            "max": 365.25,
+            "min": 365.0,
+            "val": 365.0
+        },
+        "solarheat__tcylaft6__P_120": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.0147718711338207
+        },
+        "solarheat__tcylaft6__P_130": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.0365790192242577
+        },
+        "solarheat__tcylaft6__P_140": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.0462527065824947
+        },
+        "solarheat__tcylaft6__P_150": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.118566380880683
+        },
+        "solarheat__tcylaft6__P_155": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.1933896115295597
+        },
+        "solarheat__tcylaft6__P_160": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.4244515949959546
+        },
+        "solarheat__tcylaft6__P_170": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.5983332117829019
+        },
+        "solarheat__tcylaft6__P_45": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.8765105691525865
+        },
+        "solarheat__tcylaft6__P_60": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.6795278785811332
+        },
+        "solarheat__tcylaft6__P_75": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.4537700377339573
+        },
+        "solarheat__tcylaft6__P_90": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.2463578481032682
+        },
+        "solarheat__tcylaft6__ampl": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.1366193627802836
+        },
+        "solarheat__tcylaft6__bias": {
+            "frozen": true,
+            "max": 2.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_120": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0
+        },
+        "solarheat__tcylaft6__dP_130": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0
+        },
+        "solarheat__tcylaft6__dP_140": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0
+        },
+        "solarheat__tcylaft6__dP_150": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0
+        },
+        "solarheat__tcylaft6__dP_155": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0
+        },
+        "solarheat__tcylaft6__dP_160": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0
+        },
+        "solarheat__tcylaft6__dP_170": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0
+        },
+        "solarheat__tcylaft6__dP_45": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0
+        },
+        "solarheat__tcylaft6__dP_60": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0
+        },
+        "solarheat__tcylaft6__dP_75": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0
+        },
+        "solarheat__tcylaft6__dP_90": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0
+        },
+        "solarheat__tcylaft6__tau": {
+            "frozen": true,
+            "max": 365.25,
+            "min": 365.0,
+            "val": 365.0
+        },
+        "solarheat_off_nom_roll__cc0__P_minus_y": {
+            "frozen": true,
+            "max": 2,
+            "min": -2,
+            "val": 0.5072537601098754
+        },
+        "solarheat_off_nom_roll__cc0__P_plus_y": {
+            "frozen": true,
+            "max": 2,
+            "min": -2,
+            "val": 0.3470532207597769
+        },
+        "solarheat_off_nom_roll__tcylaft6__P_minus_y": {
+            "frozen": true,
+            "max": 2,
+            "min": -2,
+            "val": 0.16828067192901655
+        },
+        "solarheat_off_nom_roll__tcylaft6__P_plus_y": {
+            "frozen": true,
+            "max": 2,
+            "min": -2,
+            "val": 0.1845109563960367
+        },
+        "tstart": "2014:001:12:02:32.816",
+        "tstop": "2018:150:11:53:58.816"
+    },
     {
-        "coupling__tcylaft6__tcylaft6_0__tau": 127.14013238048582, 
-        "date": "2016:314:20:30:14.991", 
-        "fit_stat": 4348431.223261227, 
-        "heatsink__tcylaft6_0__T": 7.202258699852631, 
-        "heatsink__tcylaft6_0__tau": 19.035016415258287, 
-        "method": "moncar", 
-        "solarheat__tcylaft6_0__P_100": 2.359720285283332, 
-        "solarheat__tcylaft6_0__P_110": 2.3064538526792386, 
-        "solarheat__tcylaft6_0__P_120": 2.0473226461437735, 
-        "solarheat__tcylaft6_0__P_130": 1.6458783588760666, 
-        "solarheat__tcylaft6_0__P_140": 1.3693067570725783, 
-        "solarheat__tcylaft6_0__P_150": 0.8739376085166018, 
-        "solarheat__tcylaft6_0__P_160": 0.4509071715782094, 
-        "solarheat__tcylaft6_0__P_180": 1.999991811115132, 
-        "solarheat__tcylaft6_0__P_45": 1.8196489546184027, 
-        "solarheat__tcylaft6_0__P_60": 1.9850262775410807, 
-        "solarheat__tcylaft6_0__P_80": 2.196123302096948, 
-        "solarheat__tcylaft6_0__P_90": 2.295447520811069, 
-        "solarheat__tcylaft6_0__ampl": 0.06900189386119292, 
-        "solarheat__tcylaft6_0__bias": 0.0, 
-        "solarheat__tcylaft6_0__dP_100": 0.2, 
-        "solarheat__tcylaft6_0__dP_110": 0.16733738555674266, 
-        "solarheat__tcylaft6_0__dP_120": 0.11837692281328732, 
-        "solarheat__tcylaft6_0__dP_130": 0.11, 
-        "solarheat__tcylaft6_0__dP_140": 0.11614117573923835, 
-        "solarheat__tcylaft6_0__dP_150": 0.09141459271880145, 
-        "solarheat__tcylaft6_0__dP_160": 0.045477378820906286, 
-        "solarheat__tcylaft6_0__dP_180": 0.0, 
-        "solarheat__tcylaft6_0__dP_45": 0.03924789356239728, 
-        "solarheat__tcylaft6_0__dP_60": 0.15248924198683483, 
-        "solarheat__tcylaft6_0__dP_80": 0.2, 
-        "solarheat__tcylaft6_0__dP_90": 0.2595462502455334, 
-        "solarheat__tcylaft6_0__tau": 365.0, 
-        "solarheat_off_nom_roll__tcylaft6__P_minus_y": 0.16689009199097632, 
-        "solarheat_off_nom_roll__tcylaft6__P_plus_y": 0.11162655576785337, 
-        "tstart": "2014:300:12:02:40.816", 
-        "tstop": "2016:300:11:53:27.816"
-    }, 
+        "coupling__tcylaft6__cc0__tau": {
+            "frozen": false,
+            "max": 200.0,
+            "min": 2.0,
+            "val": 25.675116629340824
+        },
+        "date": "2018:258:12:10:08.767",
+        "final_eval_num": "24285",
+        "fit_stat": 27094869.1538897,
+        "heatsink__cc0__T": {
+            "frozen": true,
+            "max": 100.0,
+            "min": -300.0,
+            "val": 11.508268020529213
+        },
+        "heatsink__cc0__tau": {
+            "frozen": true,
+            "max": 400.0,
+            "min": 2.0,
+            "val": 112.84830663495943
+        },
+        "heatsink__tcylaft6__T": {
+            "frozen": true,
+            "max": 100.0,
+            "min": -300.0,
+            "val": 58.17353103583307
+        },
+        "heatsink__tcylaft6__tau": {
+            "frozen": true,
+            "max": 400.0,
+            "min": 2.0,
+            "val": 16.255880671159918
+        },
+        "method": "moncar",
+        "solarheat__cc0__P_120": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": 0.37762908203269296
+        },
+        "solarheat__cc0__P_130": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": 0.1857376382366844
+        },
+        "solarheat__cc0__P_140": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": 0.13520581767244896
+        },
+        "solarheat__cc0__P_150": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": 0.0012755423199746708
+        },
+        "solarheat__cc0__P_155": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -0.029413344457157174
+        },
+        "solarheat__cc0__P_160": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -0.011388726135779506
+        },
+        "solarheat__cc0__P_170": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": 0.4646608659140738
+        },
+        "solarheat__cc0__P_45": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": 0.5138202135775761
+        },
+        "solarheat__cc0__P_60": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": 0.4369177086377181
+        },
+        "solarheat__cc0__P_75": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": 0.34051747261805565
+        },
+        "solarheat__cc0__P_90": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": 0.4212844664006303
+        },
+        "solarheat__cc0__ampl": {
+            "frozen": false,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.009496841098670793
+        },
+        "solarheat__cc0__bias": {
+            "frozen": true,
+            "max": 2.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_120": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_130": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_140": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_150": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_155": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_160": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_170": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_45": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_60": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_75": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_90": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__tau": {
+            "frozen": true,
+            "max": 365.25,
+            "min": 365.0,
+            "val": 365.0
+        },
+        "solarheat__tcylaft6__P_120": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.0147718711338207
+        },
+        "solarheat__tcylaft6__P_130": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.0365790192242577
+        },
+        "solarheat__tcylaft6__P_140": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.0462527065824947
+        },
+        "solarheat__tcylaft6__P_150": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.118566380880683
+        },
+        "solarheat__tcylaft6__P_155": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.1933896115295597
+        },
+        "solarheat__tcylaft6__P_160": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.4244515949959546
+        },
+        "solarheat__tcylaft6__P_170": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.5983332117829019
+        },
+        "solarheat__tcylaft6__P_45": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.8765105691525865
+        },
+        "solarheat__tcylaft6__P_60": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.6795278785811332
+        },
+        "solarheat__tcylaft6__P_75": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.4537700377339573
+        },
+        "solarheat__tcylaft6__P_90": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.2463578481032682
+        },
+        "solarheat__tcylaft6__ampl": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.1366193627802836
+        },
+        "solarheat__tcylaft6__bias": {
+            "frozen": true,
+            "max": 2.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_120": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_130": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_140": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_150": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_155": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_160": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_170": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_45": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_60": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_75": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_90": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__tau": {
+            "frozen": true,
+            "max": 365.25,
+            "min": 365.0,
+            "val": 365.0
+        },
+        "solarheat_off_nom_roll__cc0__P_minus_y": {
+            "frozen": true,
+            "max": 2,
+            "min": -2,
+            "val": 0.5072537601098754
+        },
+        "solarheat_off_nom_roll__cc0__P_plus_y": {
+            "frozen": true,
+            "max": 2,
+            "min": -2,
+            "val": 0.3470532207597769
+        },
+        "solarheat_off_nom_roll__tcylaft6__P_minus_y": {
+            "frozen": true,
+            "max": 2,
+            "min": -2,
+            "val": 0.16828067192901655
+        },
+        "solarheat_off_nom_roll__tcylaft6__P_plus_y": {
+            "frozen": true,
+            "max": 2,
+            "min": -2,
+            "val": 0.1845109563960367
+        },
+        "tstart": "2014:001:12:02:32.816",
+        "tstop": "2018:150:11:53:58.816"
+    },
     {
-        "coupling__tcylaft6__tcylaft6_0__tau": 127.14013238048582, 
-        "date": "2016:314:20:31:05.237", 
-        "fit_stat": 4307847.047874413, 
-        "heatsink__tcylaft6_0__T": 5.569929542217925, 
-        "heatsink__tcylaft6_0__tau": 20.15042136773322, 
-        "method": "moncar", 
-        "solarheat__tcylaft6_0__P_100": 2.359720285283332, 
-        "solarheat__tcylaft6_0__P_110": 2.3064538526792386, 
-        "solarheat__tcylaft6_0__P_120": 2.0473226461437735, 
-        "solarheat__tcylaft6_0__P_130": 1.6458783588760666, 
-        "solarheat__tcylaft6_0__P_140": 1.3693067570725783, 
-        "solarheat__tcylaft6_0__P_150": 0.8739376085166018, 
-        "solarheat__tcylaft6_0__P_160": 0.4509071715782094, 
-        "solarheat__tcylaft6_0__P_180": 1.999991811115132, 
-        "solarheat__tcylaft6_0__P_45": 1.8196489546184027, 
-        "solarheat__tcylaft6_0__P_60": 1.9850262775410807, 
-        "solarheat__tcylaft6_0__P_80": 2.196123302096948, 
-        "solarheat__tcylaft6_0__P_90": 2.295447520811069, 
-        "solarheat__tcylaft6_0__ampl": 0.06900189386119292, 
-        "solarheat__tcylaft6_0__bias": 0.0, 
-        "solarheat__tcylaft6_0__dP_100": 0.2, 
-        "solarheat__tcylaft6_0__dP_110": 0.16733738555674266, 
-        "solarheat__tcylaft6_0__dP_120": 0.11837692281328732, 
-        "solarheat__tcylaft6_0__dP_130": 0.11, 
-        "solarheat__tcylaft6_0__dP_140": 0.11614117573923835, 
-        "solarheat__tcylaft6_0__dP_150": 0.09141459271880145, 
-        "solarheat__tcylaft6_0__dP_160": 0.045477378820906286, 
-        "solarheat__tcylaft6_0__dP_180": 0.0, 
-        "solarheat__tcylaft6_0__dP_45": 0.03924789356239728, 
-        "solarheat__tcylaft6_0__dP_60": 0.15248924198683483, 
-        "solarheat__tcylaft6_0__dP_80": 0.2, 
-        "solarheat__tcylaft6_0__dP_90": 0.2595462502455334, 
-        "solarheat__tcylaft6_0__tau": 365.0, 
-        "solarheat_off_nom_roll__tcylaft6__P_minus_y": 0.16689009199097632, 
-        "solarheat_off_nom_roll__tcylaft6__P_plus_y": 0.11162655576785337, 
-        "tstart": "2014:300:12:02:40.816", 
-        "tstop": "2016:300:11:53:27.816"
-    }, 
+        "coupling__tcylaft6__cc0__tau": {
+            "frozen": false,
+            "max": 200.0,
+            "min": 2.0,
+            "val": 29.349118870736735
+        },
+        "date": "2018:258:12:27:30.058",
+        "final_eval_num": "27973",
+        "fit_stat": 26871041.17543039,
+        "heatsink__cc0__T": {
+            "frozen": true,
+            "max": 100.0,
+            "min": -300.0,
+            "val": 11.508268020529213
+        },
+        "heatsink__cc0__tau": {
+            "frozen": true,
+            "max": 400.0,
+            "min": 2.0,
+            "val": 112.84830663495943
+        },
+        "heatsink__tcylaft6__T": {
+            "frozen": true,
+            "max": 100.0,
+            "min": -300.0,
+            "val": 58.17353103583307
+        },
+        "heatsink__tcylaft6__tau": {
+            "frozen": true,
+            "max": 400.0,
+            "min": 2.0,
+            "val": 16.255880671159918
+        },
+        "method": "moncar",
+        "solarheat__cc0__P_120": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.37762908203269296
+        },
+        "solarheat__cc0__P_130": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.1857376382366844
+        },
+        "solarheat__cc0__P_140": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.13520581767244896
+        },
+        "solarheat__cc0__P_150": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.0012755423199746708
+        },
+        "solarheat__cc0__P_155": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -0.029413344457157174
+        },
+        "solarheat__cc0__P_160": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -0.011388726135779506
+        },
+        "solarheat__cc0__P_170": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.4646608659140738
+        },
+        "solarheat__cc0__P_45": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.5138202135775761
+        },
+        "solarheat__cc0__P_60": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.4369177086377181
+        },
+        "solarheat__cc0__P_75": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.34051747261805565
+        },
+        "solarheat__cc0__P_90": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.4212844664006303
+        },
+        "solarheat__cc0__ampl": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.009496841098670793
+        },
+        "solarheat__cc0__bias": {
+            "frozen": true,
+            "max": 2.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_120": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_130": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_140": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_150": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_155": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_160": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_170": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_45": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_60": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_75": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_90": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__tau": {
+            "frozen": true,
+            "max": 365.25,
+            "min": 365.0,
+            "val": 365.0
+        },
+        "solarheat__tcylaft6__P_120": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -1.0706263466648485
+        },
+        "solarheat__tcylaft6__P_130": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -1.0240312159695404
+        },
+        "solarheat__tcylaft6__P_140": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -1.0787400064776744
+        },
+        "solarheat__tcylaft6__P_150": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -1.1817490195851528
+        },
+        "solarheat__tcylaft6__P_155": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -1.2724376053356488
+        },
+        "solarheat__tcylaft6__P_160": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -1.3109220300844961
+        },
+        "solarheat__tcylaft6__P_170": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -1.4287159058223085
+        },
+        "solarheat__tcylaft6__P_45": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -1.8243183864987593
+        },
+        "solarheat__tcylaft6__P_60": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -1.592145527993378
+        },
+        "solarheat__tcylaft6__P_75": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -1.4142873128777944
+        },
+        "solarheat__tcylaft6__P_90": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -1.2149910978630187
+        },
+        "solarheat__tcylaft6__ampl": {
+            "frozen": false,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.13235329915208047
+        },
+        "solarheat__tcylaft6__bias": {
+            "frozen": true,
+            "max": 2.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_120": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_130": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_140": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_150": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_155": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_160": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_170": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_45": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_60": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_75": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_90": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__tau": {
+            "frozen": true,
+            "max": 365.25,
+            "min": 365.0,
+            "val": 365.0
+        },
+        "solarheat_off_nom_roll__cc0__P_minus_y": {
+            "frozen": true,
+            "max": 2,
+            "min": -2,
+            "val": 0.5072537601098754
+        },
+        "solarheat_off_nom_roll__cc0__P_plus_y": {
+            "frozen": true,
+            "max": 2,
+            "min": -2,
+            "val": 0.3470532207597769
+        },
+        "solarheat_off_nom_roll__tcylaft6__P_minus_y": {
+            "frozen": true,
+            "max": 2,
+            "min": -2,
+            "val": 0.16828067192901655
+        },
+        "solarheat_off_nom_roll__tcylaft6__P_plus_y": {
+            "frozen": true,
+            "max": 2,
+            "min": -2,
+            "val": 0.1845109563960367
+        },
+        "tstart": "2014:001:12:02:32.816",
+        "tstop": "2018:150:11:53:58.816"
+    },
     {
-        "coupling__tcylaft6__tcylaft6_0__tau": 127.14013238048582, 
-        "date": "2016:314:20:48:06.148", 
-        "fit_stat": 3890438.9619049416, 
-        "heatsink__tcylaft6_0__T": 5.569929542217925, 
-        "heatsink__tcylaft6_0__tau": 20.15042136773322, 
-        "method": "moncar", 
-        "solarheat__tcylaft6_0__P_100": 2.359720285283332, 
-        "solarheat__tcylaft6_0__P_110": 2.3064538526792386, 
-        "solarheat__tcylaft6_0__P_120": 2.0473226461437735, 
-        "solarheat__tcylaft6_0__P_130": 1.6458783588760666, 
-        "solarheat__tcylaft6_0__P_140": 1.3693067570725783, 
-        "solarheat__tcylaft6_0__P_150": 0.8739376085166018, 
-        "solarheat__tcylaft6_0__P_160": 0.4509071715782094, 
-        "solarheat__tcylaft6_0__P_180": 1.999991811115132, 
-        "solarheat__tcylaft6_0__P_45": 1.8196489546184027, 
-        "solarheat__tcylaft6_0__P_60": 1.9850262775410807, 
-        "solarheat__tcylaft6_0__P_80": 2.196123302096948, 
-        "solarheat__tcylaft6_0__P_90": 2.295447520811069, 
-        "solarheat__tcylaft6_0__ampl": 0.08180666551528686, 
-        "solarheat__tcylaft6_0__bias": 0.0, 
-        "solarheat__tcylaft6_0__dP_100": 0.3720713685223887, 
-        "solarheat__tcylaft6_0__dP_110": 0.2644579491781834, 
-        "solarheat__tcylaft6_0__dP_120": 0.1144833668957015, 
-        "solarheat__tcylaft6_0__dP_130": 0.2195716605258796, 
-        "solarheat__tcylaft6_0__dP_140": 0.19478060206023165, 
-        "solarheat__tcylaft6_0__dP_150": 0.17972724995448328, 
-        "solarheat__tcylaft6_0__dP_160": 0.17040133590772377, 
-        "solarheat__tcylaft6_0__dP_180": 0.37377028528242995, 
-        "solarheat__tcylaft6_0__dP_45": 0.12701041370474794, 
-        "solarheat__tcylaft6_0__dP_60": 0.13457158835135793, 
-        "solarheat__tcylaft6_0__dP_80": 0.1193312617757476, 
-        "solarheat__tcylaft6_0__dP_90": -0.01981232994686787, 
-        "solarheat__tcylaft6_0__tau": 365.0, 
-        "solarheat_off_nom_roll__tcylaft6__P_minus_y": 0.16689009199097632, 
-        "solarheat_off_nom_roll__tcylaft6__P_plus_y": 0.11162655576785337, 
-        "tstart": "2014:300:12:02:40.816", 
-        "tstop": "2016:300:11:53:27.816"
-    }, 
+        "coupling__tcylaft6__cc0__tau": {
+            "frozen": false,
+            "max": 200.0,
+            "min": 2.0,
+            "val": 27.804771841937946
+        },
+        "date": "2018:258:12:37:32.581",
+        "final_eval_num": "8546",
+        "fit_stat": 26592459.13358704,
+        "heatsink__cc0__T": {
+            "frozen": false,
+            "max": 100.0,
+            "min": -300.0,
+            "val": 36.57870882299056
+        },
+        "heatsink__cc0__tau": {
+            "frozen": false,
+            "max": 400.0,
+            "min": 2.0,
+            "val": 89.68995446119953
+        },
+        "heatsink__tcylaft6__T": {
+            "frozen": false,
+            "max": 100.0,
+            "min": -300.0,
+            "val": 49.5048028444783
+        },
+        "heatsink__tcylaft6__tau": {
+            "frozen": false,
+            "max": 400.0,
+            "min": 2.0,
+            "val": 21.42486675637181
+        },
+        "method": "moncar",
+        "solarheat__cc0__P_120": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.37762908203269296
+        },
+        "solarheat__cc0__P_130": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.1857376382366844
+        },
+        "solarheat__cc0__P_140": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.13520581767244896
+        },
+        "solarheat__cc0__P_150": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.0012755423199746708
+        },
+        "solarheat__cc0__P_155": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -0.029413344457157174
+        },
+        "solarheat__cc0__P_160": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -0.011388726135779506
+        },
+        "solarheat__cc0__P_170": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.4646608659140738
+        },
+        "solarheat__cc0__P_45": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.5138202135775761
+        },
+        "solarheat__cc0__P_60": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.4369177086377181
+        },
+        "solarheat__cc0__P_75": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.34051747261805565
+        },
+        "solarheat__cc0__P_90": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.4212844664006303
+        },
+        "solarheat__cc0__ampl": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.009496841098670793
+        },
+        "solarheat__cc0__bias": {
+            "frozen": true,
+            "max": 2.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_120": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_130": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_140": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_150": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_155": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_160": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_170": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_45": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_60": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_75": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_90": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__tau": {
+            "frozen": true,
+            "max": 365.25,
+            "min": 365.0,
+            "val": 365.0
+        },
+        "solarheat__tcylaft6__P_120": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.0706263466648485
+        },
+        "solarheat__tcylaft6__P_130": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.0240312159695404
+        },
+        "solarheat__tcylaft6__P_140": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.0787400064776744
+        },
+        "solarheat__tcylaft6__P_150": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.1817490195851528
+        },
+        "solarheat__tcylaft6__P_155": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.2724376053356488
+        },
+        "solarheat__tcylaft6__P_160": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.3109220300844961
+        },
+        "solarheat__tcylaft6__P_170": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.4287159058223085
+        },
+        "solarheat__tcylaft6__P_45": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.8243183864987593
+        },
+        "solarheat__tcylaft6__P_60": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.592145527993378
+        },
+        "solarheat__tcylaft6__P_75": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.4142873128777944
+        },
+        "solarheat__tcylaft6__P_90": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.2149910978630187
+        },
+        "solarheat__tcylaft6__ampl": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.13235329915208047
+        },
+        "solarheat__tcylaft6__bias": {
+            "frozen": true,
+            "max": 2.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_120": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_130": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_140": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_150": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_155": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_160": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_170": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_45": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_60": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_75": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_90": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__tau": {
+            "frozen": true,
+            "max": 365.25,
+            "min": 365.0,
+            "val": 365.0
+        },
+        "solarheat_off_nom_roll__cc0__P_minus_y": {
+            "frozen": true,
+            "max": 2,
+            "min": -2,
+            "val": 0.5072537601098754
+        },
+        "solarheat_off_nom_roll__cc0__P_plus_y": {
+            "frozen": true,
+            "max": 2,
+            "min": -2,
+            "val": 0.3470532207597769
+        },
+        "solarheat_off_nom_roll__tcylaft6__P_minus_y": {
+            "frozen": true,
+            "max": 2,
+            "min": -2,
+            "val": 0.16828067192901655
+        },
+        "solarheat_off_nom_roll__tcylaft6__P_plus_y": {
+            "frozen": true,
+            "max": 2,
+            "min": -2,
+            "val": 0.1845109563960367
+        },
+        "tstart": "2014:001:12:02:32.816",
+        "tstop": "2018:150:11:53:58.816"
+    },
     {
-        "coupling__tcylaft6__tcylaft6_0__tau": 127.14013238048582, 
-        "date": "2016:322:19:07:57.922", 
-        "fit_stat": 5427875.1673000958, 
-        "heatsink__tcylaft6_0__T": 5.569929542217925, 
-        "heatsink__tcylaft6_0__tau": 20.15042136773322, 
-        "method": null, 
-        "solarheat__tcylaft6_0__P_100": 2.173683902751355, 
-        "solarheat__tcylaft6_0__P_110": 2.1742243817787541, 
-        "solarheat__tcylaft6_0__P_120": 1.9900807478436202, 
-        "solarheat__tcylaft6_0__P_130": 1.5360921165403683, 
-        "solarheat__tcylaft6_0__P_140": 1.2719160904953795, 
-        "solarheat__tcylaft6_0__P_150": 0.78407364624308296, 
-        "solarheat__tcylaft6_0__P_160": 0.36570618383012454, 
-        "solarheat__tcylaft6_0__P_180": 1.8131059670147571, 
-        "solarheat__tcylaft6_0__P_45": 1.7561435094040678, 
-        "solarheat__tcylaft6_0__P_60": 1.917740230813294, 
-        "solarheat__tcylaft6_0__P_80": 2.1364574472586693, 
-        "solarheat__tcylaft6_0__P_90": 2.3053537229665393, 
-        "solarheat__tcylaft6_0__ampl": 0.08180666551528686, 
-        "solarheat__tcylaft6_0__bias": 0.0, 
-        "solarheat__tcylaft6_0__dP_100": 0.3720713685223887, 
-        "solarheat__tcylaft6_0__dP_110": 0.2644579491781834, 
-        "solarheat__tcylaft6_0__dP_120": 0.1144833668957015, 
-        "solarheat__tcylaft6_0__dP_130": 0.2195716605258796, 
-        "solarheat__tcylaft6_0__dP_140": 0.19478060206023165, 
-        "solarheat__tcylaft6_0__dP_150": 0.17972724995448328, 
-        "solarheat__tcylaft6_0__dP_160": 0.17040133590772377, 
-        "solarheat__tcylaft6_0__dP_180": 0.37377028528242995, 
-        "solarheat__tcylaft6_0__dP_45": 0.12701041370474794, 
-        "solarheat__tcylaft6_0__dP_60": 0.13457158835135793, 
-        "solarheat__tcylaft6_0__dP_80": 0.1193312617757476, 
-        "solarheat__tcylaft6_0__dP_90": -0.01981232994686787, 
-        "solarheat__tcylaft6_0__tau": 365.0, 
-        "solarheat_off_nom_roll__tcylaft6__P_minus_y": 0.16689009199097632, 
-        "solarheat_off_nom_roll__tcylaft6__P_plus_y": 0.11162655576785337, 
-        "tstart": "2013:300:12:04:32.816", 
-        "tstop": "2016:300:11:53:27.816"
-    }, 
+        "coupling__tcylaft6__cc0__tau": {
+            "frozen": false,
+            "max": 200.0,
+            "min": 2.0,
+            "val": 37.62704474639824
+        },
+        "date": "2018:258:12:58:08.190",
+        "final_eval_num": "28265",
+        "fit_stat": 26139601.213451058,
+        "heatsink__cc0__T": {
+            "frozen": true,
+            "max": 100.0,
+            "min": -300.0,
+            "val": 36.57870882299056
+        },
+        "heatsink__cc0__tau": {
+            "frozen": true,
+            "max": 400.0,
+            "min": 2.0,
+            "val": 89.68995446119953
+        },
+        "heatsink__tcylaft6__T": {
+            "frozen": true,
+            "max": 100.0,
+            "min": -300.0,
+            "val": 49.5048028444783
+        },
+        "heatsink__tcylaft6__tau": {
+            "frozen": true,
+            "max": 400.0,
+            "min": 2.0,
+            "val": 21.42486675637181
+        },
+        "method": "moncar",
+        "solarheat__cc0__P_120": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": 0.4487299510764939
+        },
+        "solarheat__cc0__P_130": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": 0.2120107198619352
+        },
+        "solarheat__cc0__P_140": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": 0.17349554764775127
+        },
+        "solarheat__cc0__P_150": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": 0.016810166291524212
+        },
+        "solarheat__cc0__P_155": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -0.009924903129618669
+        },
+        "solarheat__cc0__P_160": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -0.044382922845760106
+        },
+        "solarheat__cc0__P_170": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": 0.49506062346119256
+        },
+        "solarheat__cc0__P_45": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": 0.6931509465811395
+        },
+        "solarheat__cc0__P_60": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": 0.573189159693974
+        },
+        "solarheat__cc0__P_75": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": 0.43718488505800945
+        },
+        "solarheat__cc0__P_90": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": 0.4919769029734865
+        },
+        "solarheat__cc0__ampl": {
+            "frozen": false,
+            "max": 1.0,
+            "min": -1.0,
+            "val": -0.0004995186090524387
+        },
+        "solarheat__cc0__bias": {
+            "frozen": true,
+            "max": 2.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_120": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_130": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_140": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_150": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_155": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_160": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_170": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_45": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_60": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_75": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_90": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__tau": {
+            "frozen": true,
+            "max": 365.25,
+            "min": 365.0,
+            "val": 365.0
+        },
+        "solarheat__tcylaft6__P_120": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.0706263466648485
+        },
+        "solarheat__tcylaft6__P_130": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.0240312159695404
+        },
+        "solarheat__tcylaft6__P_140": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.0787400064776744
+        },
+        "solarheat__tcylaft6__P_150": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.1817490195851528
+        },
+        "solarheat__tcylaft6__P_155": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.2724376053356488
+        },
+        "solarheat__tcylaft6__P_160": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.3109220300844961
+        },
+        "solarheat__tcylaft6__P_170": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.4287159058223085
+        },
+        "solarheat__tcylaft6__P_45": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.8243183864987593
+        },
+        "solarheat__tcylaft6__P_60": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.592145527993378
+        },
+        "solarheat__tcylaft6__P_75": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.4142873128777944
+        },
+        "solarheat__tcylaft6__P_90": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.2149910978630187
+        },
+        "solarheat__tcylaft6__ampl": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.13235329915208047
+        },
+        "solarheat__tcylaft6__bias": {
+            "frozen": true,
+            "max": 2.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_120": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_130": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_140": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_150": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_155": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_160": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_170": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_45": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_60": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_75": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_90": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__tau": {
+            "frozen": true,
+            "max": 365.25,
+            "min": 365.0,
+            "val": 365.0
+        },
+        "solarheat_off_nom_roll__cc0__P_minus_y": {
+            "frozen": false,
+            "max": 2,
+            "min": -2,
+            "val": -0.06848230090704852
+        },
+        "solarheat_off_nom_roll__cc0__P_plus_y": {
+            "frozen": false,
+            "max": 2,
+            "min": -2,
+            "val": 0.6900768177678535
+        },
+        "solarheat_off_nom_roll__tcylaft6__P_minus_y": {
+            "frozen": true,
+            "max": 2,
+            "min": -2,
+            "val": 0.16828067192901655
+        },
+        "solarheat_off_nom_roll__tcylaft6__P_plus_y": {
+            "frozen": true,
+            "max": 2,
+            "min": -2,
+            "val": 0.1845109563960367
+        },
+        "tstart": "2014:001:12:02:32.816",
+        "tstop": "2018:150:11:53:58.816"
+    },
     {
-        "coupling__tcylaft6__tcylaft6_0__tau": 125.96144553374542, 
-        "date": "2016:322:19:26:14.256", 
-        "fit_stat": 4974477.0631486671, 
-        "heatsink__tcylaft6_0__T": 5.5699295422179249, 
-        "heatsink__tcylaft6_0__tau": 20.15042136773322, 
-        "method": "moncar", 
-        "solarheat__tcylaft6_0__P_100": 2.083008048907744, 
-        "solarheat__tcylaft6_0__P_110": 2.0653885234151499, 
-        "solarheat__tcylaft6_0__P_120": 1.8805422067103001, 
-        "solarheat__tcylaft6_0__P_130": 1.5915423543126397, 
-        "solarheat__tcylaft6_0__P_140": 1.2622202698765079, 
-        "solarheat__tcylaft6_0__P_150": 0.84423924123394822, 
-        "solarheat__tcylaft6_0__P_160": 0.39048601746353478, 
-        "solarheat__tcylaft6_0__P_180": 1.9606928178598484, 
-        "solarheat__tcylaft6_0__P_45": 1.7367913537610207, 
-        "solarheat__tcylaft6_0__P_60": 1.9052084417852613, 
-        "solarheat__tcylaft6_0__P_80": 2.0399587551118676, 
-        "solarheat__tcylaft6_0__P_90": 2.0506214255373116, 
-        "solarheat__tcylaft6_0__ampl": 0.081806665515286855, 
-        "solarheat__tcylaft6_0__bias": 0.0, 
-        "solarheat__tcylaft6_0__dP_100": 0.3720713685223887, 
-        "solarheat__tcylaft6_0__dP_110": 0.26445794917818338, 
-        "solarheat__tcylaft6_0__dP_120": 0.1144833668957015, 
-        "solarheat__tcylaft6_0__dP_130": 0.21957166052587959, 
-        "solarheat__tcylaft6_0__dP_140": 0.19478060206023165, 
-        "solarheat__tcylaft6_0__dP_150": 0.17972724995448328, 
-        "solarheat__tcylaft6_0__dP_160": 0.17040133590772377, 
-        "solarheat__tcylaft6_0__dP_180": 0.37377028528242995, 
-        "solarheat__tcylaft6_0__dP_45": 0.12701041370474794, 
-        "solarheat__tcylaft6_0__dP_60": 0.13457158835135793, 
-        "solarheat__tcylaft6_0__dP_80": 0.1193312617757476, 
-        "solarheat__tcylaft6_0__dP_90": -0.019812329946867869, 
-        "solarheat__tcylaft6_0__tau": 365.0, 
-        "solarheat_off_nom_roll__tcylaft6__P_minus_y": 0.11922566959054204, 
-        "solarheat_off_nom_roll__tcylaft6__P_plus_y": 0.1313792852252203, 
-        "tstart": "2013:300:12:04:32.816", 
-        "tstop": "2016:300:11:53:27.816"
-    }, 
+        "coupling__tcylaft6__cc0__tau": {
+            "frozen": false,
+            "max": 200.0,
+            "min": 2.0,
+            "val": 41.686352635406195
+        },
+        "date": "2018:258:13:58:28.220",
+        "final_eval_num": "32955",
+        "fit_stat": 26018124.0172729,
+        "heatsink__cc0__T": {
+            "frozen": true,
+            "max": 100.0,
+            "min": -300.0,
+            "val": 36.57870882299056
+        },
+        "heatsink__cc0__tau": {
+            "frozen": true,
+            "max": 400.0,
+            "min": 2.0,
+            "val": 89.68995446119953
+        },
+        "heatsink__tcylaft6__T": {
+            "frozen": true,
+            "max": 100.0,
+            "min": -300.0,
+            "val": 49.5048028444783
+        },
+        "heatsink__tcylaft6__tau": {
+            "frozen": true,
+            "max": 400.0,
+            "min": 2.0,
+            "val": 21.42486675637181
+        },
+        "method": "moncar",
+        "solarheat__cc0__P_120": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.4487299510764939
+        },
+        "solarheat__cc0__P_130": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.2120107198619352
+        },
+        "solarheat__cc0__P_140": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.17349554764775127
+        },
+        "solarheat__cc0__P_150": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.016810166291524212
+        },
+        "solarheat__cc0__P_155": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -0.009924903129618669
+        },
+        "solarheat__cc0__P_160": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -0.044382922845760106
+        },
+        "solarheat__cc0__P_170": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.49506062346119256
+        },
+        "solarheat__cc0__P_45": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.6931509465811395
+        },
+        "solarheat__cc0__P_60": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.573189159693974
+        },
+        "solarheat__cc0__P_75": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.43718488505800945
+        },
+        "solarheat__cc0__P_90": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.4919769029734865
+        },
+        "solarheat__cc0__ampl": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": -0.0004995186090524387
+        },
+        "solarheat__cc0__bias": {
+            "frozen": true,
+            "max": 2.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_120": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_130": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_140": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_150": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_155": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_160": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_170": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_45": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_60": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_75": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_90": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__tau": {
+            "frozen": true,
+            "max": 365.25,
+            "min": 365.0,
+            "val": 365.0
+        },
+        "solarheat__tcylaft6__P_120": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -1.034152175009766
+        },
+        "solarheat__tcylaft6__P_130": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -0.9860304632344817
+        },
+        "solarheat__tcylaft6__P_140": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -1.041889407014247
+        },
+        "solarheat__tcylaft6__P_150": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -1.1396677924678151
+        },
+        "solarheat__tcylaft6__P_155": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -1.216806091787016
+        },
+        "solarheat__tcylaft6__P_160": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -1.2578290598427586
+        },
+        "solarheat__tcylaft6__P_170": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -1.3398772400876746
+        },
+        "solarheat__tcylaft6__P_45": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -1.6864083520415583
+        },
+        "solarheat__tcylaft6__P_60": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -1.4773041565566718
+        },
+        "solarheat__tcylaft6__P_75": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -1.3211881268281536
+        },
+        "solarheat__tcylaft6__P_90": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -1.1548558608480248
+        },
+        "solarheat__tcylaft6__ampl": {
+            "frozen": false,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.1264405779385537
+        },
+        "solarheat__tcylaft6__bias": {
+            "frozen": true,
+            "max": 2.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_120": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_130": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_140": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_150": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_155": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_160": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_170": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_45": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_60": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_75": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_90": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__tau": {
+            "frozen": true,
+            "max": 365.25,
+            "min": 365.0,
+            "val": 365.0
+        },
+        "solarheat_off_nom_roll__cc0__P_minus_y": {
+            "frozen": true,
+            "max": 2,
+            "min": -2,
+            "val": -0.06848230090704852
+        },
+        "solarheat_off_nom_roll__cc0__P_plus_y": {
+            "frozen": true,
+            "max": 2,
+            "min": -2,
+            "val": 0.6900768177678535
+        },
+        "solarheat_off_nom_roll__tcylaft6__P_minus_y": {
+            "frozen": false,
+            "max": 2,
+            "min": -2,
+            "val": 0.1054137097040723
+        },
+        "solarheat_off_nom_roll__tcylaft6__P_plus_y": {
+            "frozen": false,
+            "max": 2,
+            "min": -2,
+            "val": 0.24953953646838054
+        },
+        "tstart": "2014:001:12:02:32.816",
+        "tstop": "2018:150:11:53:58.816"
+    },
     {
-        "coupling__tcylaft6__tcylaft6_0__tau": 125.96144553374542, 
-        "date": "2016:322:19:45:32.361", 
-        "fit_stat": 4840922.7281041685, 
-        "heatsink__tcylaft6_0__T": 5.5699295422179249, 
-        "heatsink__tcylaft6_0__tau": 20.15042136773322, 
-        "method": "moncar", 
-        "solarheat__tcylaft6_0__P_100": 2.083008048907744, 
-        "solarheat__tcylaft6_0__P_110": 2.0653885234151499, 
-        "solarheat__tcylaft6_0__P_120": 1.8805422067103001, 
-        "solarheat__tcylaft6_0__P_130": 1.5915423543126397, 
-        "solarheat__tcylaft6_0__P_140": 1.2622202698765079, 
-        "solarheat__tcylaft6_0__P_150": 0.84423924123394822, 
-        "solarheat__tcylaft6_0__P_160": 0.39048601746353478, 
-        "solarheat__tcylaft6_0__P_180": 1.9606928178598484, 
-        "solarheat__tcylaft6_0__P_45": 1.7367913537610207, 
-        "solarheat__tcylaft6_0__P_60": 1.9052084417852613, 
-        "solarheat__tcylaft6_0__P_80": 2.0399587551118676, 
-        "solarheat__tcylaft6_0__P_90": 2.0506214255373116, 
-        "solarheat__tcylaft6_0__ampl": 0.081806665515286855, 
-        "solarheat__tcylaft6_0__bias": 0.0, 
-        "solarheat__tcylaft6_0__dP_100": 0.25059384088956638, 
-        "solarheat__tcylaft6_0__dP_110": 0.24785320978196304, 
-        "solarheat__tcylaft6_0__dP_120": 0.17728335178136606, 
-        "solarheat__tcylaft6_0__dP_130": 0.22183956807374561, 
-        "solarheat__tcylaft6_0__dP_140": 0.19927551656668463, 
-        "solarheat__tcylaft6_0__dP_150": 0.17465518078563746, 
-        "solarheat__tcylaft6_0__dP_160": 0.17841576619195629, 
-        "solarheat__tcylaft6_0__dP_180": 0.49999711514768763, 
-        "solarheat__tcylaft6_0__dP_45": 0.13633667968033217, 
-        "solarheat__tcylaft6_0__dP_60": 0.090896114439088044, 
-        "solarheat__tcylaft6_0__dP_80": 0.1290713098416999, 
-        "solarheat__tcylaft6_0__dP_90": 0.16070368647255273, 
-        "solarheat__tcylaft6_0__tau": 365.0, 
-        "solarheat_off_nom_roll__tcylaft6__P_minus_y": 0.11922566959054204, 
-        "solarheat_off_nom_roll__tcylaft6__P_plus_y": 0.1313792852252203, 
-        "tstart": "2013:300:12:04:32.816", 
-        "tstop": "2016:300:11:53:27.816"
+        "coupling__tcylaft6__cc0__tau": {
+            "frozen": true,
+            "max": 200.0,
+            "min": 2.0,
+            "val": 41.686352635406195
+        },
+        "date": "2018:258:14:34:52.426",
+        "final_eval_num": "23167",
+        "fit_stat": 4529292.161241988,
+        "heatsink__cc0__T": {
+            "frozen": true,
+            "max": 100.0,
+            "min": -300.0,
+            "val": 36.57870882299056
+        },
+        "heatsink__cc0__tau": {
+            "frozen": true,
+            "max": 400.0,
+            "min": 2.0,
+            "val": 89.68995446119953
+        },
+        "heatsink__tcylaft6__T": {
+            "frozen": true,
+            "max": 100.0,
+            "min": -300.0,
+            "val": 49.5048028444783
+        },
+        "heatsink__tcylaft6__tau": {
+            "frozen": true,
+            "max": 400.0,
+            "min": 2.0,
+            "val": 21.42486675637181
+        },
+        "method": "moncar",
+        "solarheat__cc0__P_120": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.4487299510764939
+        },
+        "solarheat__cc0__P_130": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.2120107198619352
+        },
+        "solarheat__cc0__P_140": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.17349554764775127
+        },
+        "solarheat__cc0__P_150": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.016810166291524212
+        },
+        "solarheat__cc0__P_155": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -0.009924903129618669
+        },
+        "solarheat__cc0__P_160": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -0.044382922845760106
+        },
+        "solarheat__cc0__P_170": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.49506062346119256
+        },
+        "solarheat__cc0__P_45": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.6931509465811395
+        },
+        "solarheat__cc0__P_60": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.573189159693974
+        },
+        "solarheat__cc0__P_75": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.43718488505800945
+        },
+        "solarheat__cc0__P_90": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.4919769029734865
+        },
+        "solarheat__cc0__ampl": {
+            "frozen": false,
+            "max": 1.0,
+            "min": -1.0,
+            "val": -0.007040485431456058
+        },
+        "solarheat__cc0__bias": {
+            "frozen": true,
+            "max": 2.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_120": {
+            "frozen": false,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.11505402359152457
+        },
+        "solarheat__cc0__dP_130": {
+            "frozen": false,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.10634995186696317
+        },
+        "solarheat__cc0__dP_140": {
+            "frozen": false,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.1264335965115952
+        },
+        "solarheat__cc0__dP_150": {
+            "frozen": false,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.1460223932512542
+        },
+        "solarheat__cc0__dP_155": {
+            "frozen": false,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.11800808470523017
+        },
+        "solarheat__cc0__dP_160": {
+            "frozen": false,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.13436929544135323
+        },
+        "solarheat__cc0__dP_170": {
+            "frozen": false,
+            "max": 1.0,
+            "min": -1.0,
+            "val": -0.2039741482660117
+        },
+        "solarheat__cc0__dP_45": {
+            "frozen": false,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.04298772664264534
+        },
+        "solarheat__cc0__dP_60": {
+            "frozen": false,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.05007884851447267
+        },
+        "solarheat__cc0__dP_75": {
+            "frozen": false,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.03456028021128707
+        },
+        "solarheat__cc0__dP_90": {
+            "frozen": false,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.06714262098871841
+        },
+        "solarheat__cc0__tau": {
+            "frozen": true,
+            "max": 365.25,
+            "min": 365.0,
+            "val": 365.0
+        },
+        "solarheat__tcylaft6__P_120": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.034152175009766
+        },
+        "solarheat__tcylaft6__P_130": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -0.9860304632344817
+        },
+        "solarheat__tcylaft6__P_140": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.041889407014247
+        },
+        "solarheat__tcylaft6__P_150": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.1396677924678151
+        },
+        "solarheat__tcylaft6__P_155": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.216806091787016
+        },
+        "solarheat__tcylaft6__P_160": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.2578290598427586
+        },
+        "solarheat__tcylaft6__P_170": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.3398772400876746
+        },
+        "solarheat__tcylaft6__P_45": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.6864083520415583
+        },
+        "solarheat__tcylaft6__P_60": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.4773041565566718
+        },
+        "solarheat__tcylaft6__P_75": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.3211881268281536
+        },
+        "solarheat__tcylaft6__P_90": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.1548558608480248
+        },
+        "solarheat__tcylaft6__ampl": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.1264405779385537
+        },
+        "solarheat__tcylaft6__bias": {
+            "frozen": true,
+            "max": 2.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_120": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_130": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_140": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_150": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_155": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_160": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_170": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_45": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_60": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_75": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_90": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__tau": {
+            "frozen": true,
+            "max": 365.25,
+            "min": 365.0,
+            "val": 365.0
+        },
+        "solarheat_off_nom_roll__cc0__P_minus_y": {
+            "frozen": true,
+            "max": 2,
+            "min": -2,
+            "val": -0.06848230090704852
+        },
+        "solarheat_off_nom_roll__cc0__P_plus_y": {
+            "frozen": true,
+            "max": 2,
+            "min": -2,
+            "val": 0.6900768177678535
+        },
+        "solarheat_off_nom_roll__tcylaft6__P_minus_y": {
+            "frozen": true,
+            "max": 2,
+            "min": -2,
+            "val": 0.1054137097040723
+        },
+        "solarheat_off_nom_roll__tcylaft6__P_plus_y": {
+            "frozen": true,
+            "max": 2,
+            "min": -2,
+            "val": 0.24953953646838054
+        },
+        "tstart": "2014:001:12:02:32.816",
+        "tstop": "2018:150:11:53:58.816"
+    },
+    {
+        "coupling__tcylaft6__cc0__tau": {
+            "frozen": false,
+            "max": 200.0,
+            "min": 2.0,
+            "val": 37.61979122764469
+        },
+        "date": "2018:258:14:56:26.289",
+        "final_eval_num": "27796",
+        "fit_stat": 2447908.0862697084,
+        "heatsink__cc0__T": {
+            "frozen": true,
+            "max": 100.0,
+            "min": -300.0,
+            "val": 36.57870882299056
+        },
+        "heatsink__cc0__tau": {
+            "frozen": true,
+            "max": 400.0,
+            "min": 2.0,
+            "val": 89.68995446119953
+        },
+        "heatsink__tcylaft6__T": {
+            "frozen": true,
+            "max": 100.0,
+            "min": -300.0,
+            "val": 49.5048028444783
+        },
+        "heatsink__tcylaft6__tau": {
+            "frozen": true,
+            "max": 400.0,
+            "min": 2.0,
+            "val": 21.42486675637181
+        },
+        "method": "moncar",
+        "solarheat__cc0__P_120": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": 0.47246685051037635
+        },
+        "solarheat__cc0__P_130": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": 0.30462513799473034
+        },
+        "solarheat__cc0__P_140": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": 0.1546839123160394
+        },
+        "solarheat__cc0__P_150": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -0.022326141496205747
+        },
+        "solarheat__cc0__P_155": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -0.13696021544074807
+        },
+        "solarheat__cc0__P_160": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -0.14590497035880476
+        },
+        "solarheat__cc0__P_170": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -0.06208482598345267
+        },
+        "solarheat__cc0__P_45": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": 0.5563492368201418
+        },
+        "solarheat__cc0__P_60": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": 0.5640719109146409
+        },
+        "solarheat__cc0__P_75": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": 0.5843295512842579
+        },
+        "solarheat__cc0__P_90": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": 0.5832832447137708
+        },
+        "solarheat__cc0__ampl": {
+            "frozen": false,
+            "max": 1.0,
+            "min": -1.0,
+            "val": -0.0029238893382666246
+        },
+        "solarheat__cc0__bias": {
+            "frozen": true,
+            "max": 2.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_120": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.11505402359152457
+        },
+        "solarheat__cc0__dP_130": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.10634995186696317
+        },
+        "solarheat__cc0__dP_140": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.1264335965115952
+        },
+        "solarheat__cc0__dP_150": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.1460223932512542
+        },
+        "solarheat__cc0__dP_155": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.11800808470523017
+        },
+        "solarheat__cc0__dP_160": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.13436929544135323
+        },
+        "solarheat__cc0__dP_170": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": -0.2039741482660117
+        },
+        "solarheat__cc0__dP_45": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.04298772664264534
+        },
+        "solarheat__cc0__dP_60": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.05007884851447267
+        },
+        "solarheat__cc0__dP_75": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.03456028021128707
+        },
+        "solarheat__cc0__dP_90": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.06714262098871841
+        },
+        "solarheat__cc0__tau": {
+            "frozen": true,
+            "max": 365.25,
+            "min": 365.0,
+            "val": 365.0
+        },
+        "solarheat__tcylaft6__P_120": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.034152175009766
+        },
+        "solarheat__tcylaft6__P_130": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -0.9860304632344817
+        },
+        "solarheat__tcylaft6__P_140": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.041889407014247
+        },
+        "solarheat__tcylaft6__P_150": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.1396677924678151
+        },
+        "solarheat__tcylaft6__P_155": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.216806091787016
+        },
+        "solarheat__tcylaft6__P_160": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.2578290598427586
+        },
+        "solarheat__tcylaft6__P_170": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.3398772400876746
+        },
+        "solarheat__tcylaft6__P_45": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.6864083520415583
+        },
+        "solarheat__tcylaft6__P_60": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.4773041565566718
+        },
+        "solarheat__tcylaft6__P_75": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.3211881268281536
+        },
+        "solarheat__tcylaft6__P_90": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.1548558608480248
+        },
+        "solarheat__tcylaft6__ampl": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.1264405779385537
+        },
+        "solarheat__tcylaft6__bias": {
+            "frozen": true,
+            "max": 2.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_120": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_130": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_140": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_150": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_155": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_160": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_170": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_45": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_60": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_75": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_90": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__tau": {
+            "frozen": true,
+            "max": 365.25,
+            "min": 365.0,
+            "val": 365.0
+        },
+        "solarheat_off_nom_roll__cc0__P_minus_y": {
+            "frozen": false,
+            "max": 2,
+            "min": -2,
+            "val": 0.5317010196538007
+        },
+        "solarheat_off_nom_roll__cc0__P_plus_y": {
+            "frozen": false,
+            "max": 2,
+            "min": -2,
+            "val": 0.409045455469855
+        },
+        "solarheat_off_nom_roll__tcylaft6__P_minus_y": {
+            "frozen": true,
+            "max": 2,
+            "min": -2,
+            "val": 0.1054137097040723
+        },
+        "solarheat_off_nom_roll__tcylaft6__P_plus_y": {
+            "frozen": true,
+            "max": 2,
+            "min": -2,
+            "val": 0.24953953646838054
+        },
+        "tstart": "2014:001:12:02:32.816",
+        "tstop": "2018:150:11:53:58.816"
+    },
+    {
+        "coupling__tcylaft6__cc0__tau": {
+            "frozen": false,
+            "max": 200.0,
+            "min": 2.0,
+            "val": 36.86398454182511
+        },
+        "date": "2018:258:15:16:11.145",
+        "final_eval_num": "32419",
+        "fit_stat": 2393239.221959785,
+        "heatsink__cc0__T": {
+            "frozen": true,
+            "max": 100.0,
+            "min": -300.0,
+            "val": 36.57870882299056
+        },
+        "heatsink__cc0__tau": {
+            "frozen": true,
+            "max": 400.0,
+            "min": 2.0,
+            "val": 89.68995446119953
+        },
+        "heatsink__tcylaft6__T": {
+            "frozen": true,
+            "max": 100.0,
+            "min": -300.0,
+            "val": 49.5048028444783
+        },
+        "heatsink__tcylaft6__tau": {
+            "frozen": true,
+            "max": 400.0,
+            "min": 2.0,
+            "val": 21.42486675637181
+        },
+        "method": "moncar",
+        "solarheat__cc0__P_120": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.47246685051037635
+        },
+        "solarheat__cc0__P_130": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.30462513799473034
+        },
+        "solarheat__cc0__P_140": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.1546839123160394
+        },
+        "solarheat__cc0__P_150": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -0.022326141496205747
+        },
+        "solarheat__cc0__P_155": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -0.13696021544074807
+        },
+        "solarheat__cc0__P_160": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -0.14590497035880476
+        },
+        "solarheat__cc0__P_170": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -0.06208482598345267
+        },
+        "solarheat__cc0__P_45": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.5563492368201418
+        },
+        "solarheat__cc0__P_60": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.5640719109146409
+        },
+        "solarheat__cc0__P_75": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.5843295512842579
+        },
+        "solarheat__cc0__P_90": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.5832832447137708
+        },
+        "solarheat__cc0__ampl": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": -0.0029238893382666246
+        },
+        "solarheat__cc0__bias": {
+            "frozen": true,
+            "max": 2.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_120": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.11505402359152457
+        },
+        "solarheat__cc0__dP_130": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.10634995186696317
+        },
+        "solarheat__cc0__dP_140": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.1264335965115952
+        },
+        "solarheat__cc0__dP_150": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.1460223932512542
+        },
+        "solarheat__cc0__dP_155": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.11800808470523017
+        },
+        "solarheat__cc0__dP_160": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.13436929544135323
+        },
+        "solarheat__cc0__dP_170": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": -0.2039741482660117
+        },
+        "solarheat__cc0__dP_45": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.04298772664264534
+        },
+        "solarheat__cc0__dP_60": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.05007884851447267
+        },
+        "solarheat__cc0__dP_75": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.03456028021128707
+        },
+        "solarheat__cc0__dP_90": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.06714262098871841
+        },
+        "solarheat__cc0__tau": {
+            "frozen": true,
+            "max": 365.25,
+            "min": 365.0,
+            "val": 365.0
+        },
+        "solarheat__tcylaft6__P_120": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -1.0157796366263856
+        },
+        "solarheat__tcylaft6__P_130": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -1.0115163472320874
+        },
+        "solarheat__tcylaft6__P_140": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -1.0521042811001025
+        },
+        "solarheat__tcylaft6__P_150": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -1.1353665595733407
+        },
+        "solarheat__tcylaft6__P_155": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -1.2004018098886413
+        },
+        "solarheat__tcylaft6__P_160": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -1.3100616673004566
+        },
+        "solarheat__tcylaft6__P_170": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -1.4459379579437883
+        },
+        "solarheat__tcylaft6__P_45": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -1.71112386045744
+        },
+        "solarheat__tcylaft6__P_60": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -1.511689075329988
+        },
+        "solarheat__tcylaft6__P_75": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -1.33558170544472
+        },
+        "solarheat__tcylaft6__P_90": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -1.175796793338405
+        },
+        "solarheat__tcylaft6__ampl": {
+            "frozen": false,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.1277344381214333
+        },
+        "solarheat__tcylaft6__bias": {
+            "frozen": true,
+            "max": 2.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_120": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_130": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_140": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_150": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_155": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_160": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_170": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_45": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_60": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_75": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_90": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__tau": {
+            "frozen": true,
+            "max": 365.25,
+            "min": 365.0,
+            "val": 365.0
+        },
+        "solarheat_off_nom_roll__cc0__P_minus_y": {
+            "frozen": true,
+            "max": 2,
+            "min": -2,
+            "val": 0.5317010196538007
+        },
+        "solarheat_off_nom_roll__cc0__P_plus_y": {
+            "frozen": true,
+            "max": 2,
+            "min": -2,
+            "val": 0.409045455469855
+        },
+        "solarheat_off_nom_roll__tcylaft6__P_minus_y": {
+            "frozen": false,
+            "max": 2,
+            "min": -2,
+            "val": 0.1403704986365521
+        },
+        "solarheat_off_nom_roll__tcylaft6__P_plus_y": {
+            "frozen": false,
+            "max": 2,
+            "min": -2,
+            "val": 0.10983206606570352
+        },
+        "tstart": "2014:001:12:02:32.816",
+        "tstop": "2018:150:11:53:58.816"
+    },
+    {
+        "coupling__tcylaft6__cc0__tau": {
+            "frozen": false,
+            "max": 200.0,
+            "min": 2.0,
+            "val": 41.87578762070769
+        },
+        "date": "2018:258:15:22:44.690",
+        "final_eval_num": "10873",
+        "fit_stat": 2072455.391693245,
+        "heatsink__cc0__T": {
+            "frozen": false,
+            "max": 100.0,
+            "min": -300.0,
+            "val": 12.004172208223716
+        },
+        "heatsink__cc0__tau": {
+            "frozen": false,
+            "max": 400.0,
+            "min": 2.0,
+            "val": 109.41360686503907
+        },
+        "heatsink__tcylaft6__T": {
+            "frozen": false,
+            "max": 100.0,
+            "min": -300.0,
+            "val": 59.458949796024164
+        },
+        "heatsink__tcylaft6__tau": {
+            "frozen": false,
+            "max": 400.0,
+            "min": 2.0,
+            "val": 20.01164719992392
+        },
+        "method": "moncar",
+        "solarheat__cc0__P_120": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.47246685051037635
+        },
+        "solarheat__cc0__P_130": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.30462513799473034
+        },
+        "solarheat__cc0__P_140": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.1546839123160394
+        },
+        "solarheat__cc0__P_150": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -0.022326141496205747
+        },
+        "solarheat__cc0__P_155": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -0.13696021544074807
+        },
+        "solarheat__cc0__P_160": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -0.14590497035880476
+        },
+        "solarheat__cc0__P_170": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -0.06208482598345267
+        },
+        "solarheat__cc0__P_45": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.5563492368201418
+        },
+        "solarheat__cc0__P_60": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.5640719109146409
+        },
+        "solarheat__cc0__P_75": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.5843295512842579
+        },
+        "solarheat__cc0__P_90": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.5832832447137708
+        },
+        "solarheat__cc0__ampl": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": -0.0029238893382666246
+        },
+        "solarheat__cc0__bias": {
+            "frozen": true,
+            "max": 2.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_120": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.11505402359152457
+        },
+        "solarheat__cc0__dP_130": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.10634995186696317
+        },
+        "solarheat__cc0__dP_140": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.1264335965115952
+        },
+        "solarheat__cc0__dP_150": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.1460223932512542
+        },
+        "solarheat__cc0__dP_155": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.11800808470523017
+        },
+        "solarheat__cc0__dP_160": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.13436929544135323
+        },
+        "solarheat__cc0__dP_170": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": -0.2039741482660117
+        },
+        "solarheat__cc0__dP_45": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.04298772664264534
+        },
+        "solarheat__cc0__dP_60": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.05007884851447267
+        },
+        "solarheat__cc0__dP_75": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.03456028021128707
+        },
+        "solarheat__cc0__dP_90": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.06714262098871841
+        },
+        "solarheat__cc0__tau": {
+            "frozen": true,
+            "max": 365.25,
+            "min": 365.0,
+            "val": 365.0
+        },
+        "solarheat__tcylaft6__P_120": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.0157796366263856
+        },
+        "solarheat__tcylaft6__P_130": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.0115163472320874
+        },
+        "solarheat__tcylaft6__P_140": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.0521042811001025
+        },
+        "solarheat__tcylaft6__P_150": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.1353665595733407
+        },
+        "solarheat__tcylaft6__P_155": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.2004018098886413
+        },
+        "solarheat__tcylaft6__P_160": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.3100616673004566
+        },
+        "solarheat__tcylaft6__P_170": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.4459379579437883
+        },
+        "solarheat__tcylaft6__P_45": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.71112386045744
+        },
+        "solarheat__tcylaft6__P_60": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.511689075329988
+        },
+        "solarheat__tcylaft6__P_75": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.33558170544472
+        },
+        "solarheat__tcylaft6__P_90": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.175796793338405
+        },
+        "solarheat__tcylaft6__ampl": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.1277344381214333
+        },
+        "solarheat__tcylaft6__bias": {
+            "frozen": true,
+            "max": 2.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_120": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_130": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_140": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_150": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_155": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_160": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_170": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_45": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_60": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_75": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_90": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__tau": {
+            "frozen": true,
+            "max": 365.25,
+            "min": 365.0,
+            "val": 365.0
+        },
+        "solarheat_off_nom_roll__cc0__P_minus_y": {
+            "frozen": true,
+            "max": 2,
+            "min": -2,
+            "val": 0.5317010196538007
+        },
+        "solarheat_off_nom_roll__cc0__P_plus_y": {
+            "frozen": true,
+            "max": 2,
+            "min": -2,
+            "val": 0.409045455469855
+        },
+        "solarheat_off_nom_roll__tcylaft6__P_minus_y": {
+            "frozen": true,
+            "max": 2,
+            "min": -2,
+            "val": 0.1403704986365521
+        },
+        "solarheat_off_nom_roll__tcylaft6__P_plus_y": {
+            "frozen": true,
+            "max": 2,
+            "min": -2,
+            "val": 0.10983206606570352
+        },
+        "tstart": "2014:001:12:02:32.816",
+        "tstop": "2018:150:11:53:58.816"
+    },
+    {
+        "coupling__tcylaft6__cc0__tau": {
+            "frozen": true,
+            "max": 200.0,
+            "min": 2.0,
+            "val": 41.87578762070769
+        },
+        "date": "2018:258:15:52:34.079",
+        "final_eval_num": "25780",
+        "fit_stat": 1840656.5040359164,
+        "heatsink__cc0__T": {
+            "frozen": true,
+            "max": 100.0,
+            "min": -300.0,
+            "val": 12.004172208223716
+        },
+        "heatsink__cc0__tau": {
+            "frozen": true,
+            "max": 400.0,
+            "min": 2.0,
+            "val": 109.41360686503907
+        },
+        "heatsink__tcylaft6__T": {
+            "frozen": true,
+            "max": 100.0,
+            "min": -300.0,
+            "val": 59.458949796024164
+        },
+        "heatsink__tcylaft6__tau": {
+            "frozen": true,
+            "max": 400.0,
+            "min": 2.0,
+            "val": 20.01164719992392
+        },
+        "method": "moncar",
+        "solarheat__cc0__P_120": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.47246685051037635
+        },
+        "solarheat__cc0__P_130": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.30462513799473034
+        },
+        "solarheat__cc0__P_140": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.1546839123160394
+        },
+        "solarheat__cc0__P_150": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -0.022326141496205747
+        },
+        "solarheat__cc0__P_155": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -0.13696021544074807
+        },
+        "solarheat__cc0__P_160": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -0.14590497035880476
+        },
+        "solarheat__cc0__P_170": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -0.06208482598345267
+        },
+        "solarheat__cc0__P_45": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.5563492368201418
+        },
+        "solarheat__cc0__P_60": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.5640719109146409
+        },
+        "solarheat__cc0__P_75": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.5843295512842579
+        },
+        "solarheat__cc0__P_90": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.5832832447137708
+        },
+        "solarheat__cc0__ampl": {
+            "frozen": false,
+            "max": 1.0,
+            "min": -1.0,
+            "val": -0.003086813751897204
+        },
+        "solarheat__cc0__bias": {
+            "frozen": true,
+            "max": 2.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_120": {
+            "frozen": false,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.11044191434169756
+        },
+        "solarheat__cc0__dP_130": {
+            "frozen": false,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.11423189810784957
+        },
+        "solarheat__cc0__dP_140": {
+            "frozen": false,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.1142566010757129
+        },
+        "solarheat__cc0__dP_150": {
+            "frozen": false,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.11178434804147101
+        },
+        "solarheat__cc0__dP_155": {
+            "frozen": false,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.10237434478244646
+        },
+        "solarheat__cc0__dP_160": {
+            "frozen": false,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.11927281130414952
+        },
+        "solarheat__cc0__dP_170": {
+            "frozen": false,
+            "max": 1.0,
+            "min": -1.0,
+            "val": -0.06859062563059512
+        },
+        "solarheat__cc0__dP_45": {
+            "frozen": false,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.04419124736909307
+        },
+        "solarheat__cc0__dP_60": {
+            "frozen": false,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.049852414049509734
+        },
+        "solarheat__cc0__dP_75": {
+            "frozen": false,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.07065384062229474
+        },
+        "solarheat__cc0__dP_90": {
+            "frozen": false,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.092965710077585
+        },
+        "solarheat__cc0__tau": {
+            "frozen": true,
+            "max": 365.25,
+            "min": 365.0,
+            "val": 365.0
+        },
+        "solarheat__tcylaft6__P_120": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.0157796366263856
+        },
+        "solarheat__tcylaft6__P_130": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.0115163472320874
+        },
+        "solarheat__tcylaft6__P_140": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.0521042811001025
+        },
+        "solarheat__tcylaft6__P_150": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.1353665595733407
+        },
+        "solarheat__tcylaft6__P_155": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.2004018098886413
+        },
+        "solarheat__tcylaft6__P_160": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.3100616673004566
+        },
+        "solarheat__tcylaft6__P_170": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.4459379579437883
+        },
+        "solarheat__tcylaft6__P_45": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.71112386045744
+        },
+        "solarheat__tcylaft6__P_60": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.511689075329988
+        },
+        "solarheat__tcylaft6__P_75": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.33558170544472
+        },
+        "solarheat__tcylaft6__P_90": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.175796793338405
+        },
+        "solarheat__tcylaft6__ampl": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.1277344381214333
+        },
+        "solarheat__tcylaft6__bias": {
+            "frozen": true,
+            "max": 2.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_120": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_130": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_140": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_150": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_155": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_160": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_170": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_45": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_60": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_75": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_90": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__tau": {
+            "frozen": true,
+            "max": 365.25,
+            "min": 365.0,
+            "val": 365.0
+        },
+        "solarheat_off_nom_roll__cc0__P_minus_y": {
+            "frozen": true,
+            "max": 2,
+            "min": -2,
+            "val": 0.5317010196538007
+        },
+        "solarheat_off_nom_roll__cc0__P_plus_y": {
+            "frozen": true,
+            "max": 2,
+            "min": -2,
+            "val": 0.409045455469855
+        },
+        "solarheat_off_nom_roll__tcylaft6__P_minus_y": {
+            "frozen": true,
+            "max": 2,
+            "min": -2,
+            "val": 0.1403704986365521
+        },
+        "solarheat_off_nom_roll__tcylaft6__P_plus_y": {
+            "frozen": true,
+            "max": 2,
+            "min": -2,
+            "val": 0.10983206606570352
+        },
+        "tstart": "2014:001:12:02:32.816",
+        "tstop": "2018:150:11:53:58.816"
+    },
+    {
+        "coupling__tcylaft6__cc0__tau": {
+            "frozen": true,
+            "max": 200.0,
+            "min": 2.0,
+            "val": 41.87578762070769
+        },
+        "date": "2018:258:16:21:04.037",
+        "final_eval_num": "25770",
+        "fit_stat": 1840656.5040359164,
+        "heatsink__cc0__T": {
+            "frozen": true,
+            "max": 100.0,
+            "min": -300.0,
+            "val": 12.004172208223716
+        },
+        "heatsink__cc0__tau": {
+            "frozen": true,
+            "max": 400.0,
+            "min": 2.0,
+            "val": 109.41360686503907
+        },
+        "heatsink__tcylaft6__T": {
+            "frozen": true,
+            "max": 100.0,
+            "min": -300.0,
+            "val": 59.458949796024164
+        },
+        "heatsink__tcylaft6__tau": {
+            "frozen": true,
+            "max": 400.0,
+            "min": 2.0,
+            "val": 20.01164719992392
+        },
+        "method": "moncar",
+        "solarheat__cc0__P_120": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.47246685051037635
+        },
+        "solarheat__cc0__P_130": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.30462513799473034
+        },
+        "solarheat__cc0__P_140": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.1546839123160394
+        },
+        "solarheat__cc0__P_150": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -0.022326141496205747
+        },
+        "solarheat__cc0__P_155": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -0.13696021544074807
+        },
+        "solarheat__cc0__P_160": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -0.14590497035880476
+        },
+        "solarheat__cc0__P_170": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -0.06208482598345267
+        },
+        "solarheat__cc0__P_45": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.5563492368201418
+        },
+        "solarheat__cc0__P_60": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.5640719109146409
+        },
+        "solarheat__cc0__P_75": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.5843295512842579
+        },
+        "solarheat__cc0__P_90": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.5832832447137708
+        },
+        "solarheat__cc0__ampl": {
+            "frozen": false,
+            "max": 1.0,
+            "min": -1.0,
+            "val": -0.003086813751897204
+        },
+        "solarheat__cc0__bias": {
+            "frozen": true,
+            "max": 2.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_120": {
+            "frozen": false,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.11044191434169756
+        },
+        "solarheat__cc0__dP_130": {
+            "frozen": false,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.11423189810784957
+        },
+        "solarheat__cc0__dP_140": {
+            "frozen": false,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.1142566010757129
+        },
+        "solarheat__cc0__dP_150": {
+            "frozen": false,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.11178434804147101
+        },
+        "solarheat__cc0__dP_155": {
+            "frozen": false,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.10237434478244646
+        },
+        "solarheat__cc0__dP_160": {
+            "frozen": false,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.11927281130414952
+        },
+        "solarheat__cc0__dP_170": {
+            "frozen": false,
+            "max": 1.0,
+            "min": -1.0,
+            "val": -0.06859062563059512
+        },
+        "solarheat__cc0__dP_45": {
+            "frozen": false,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.04419124736909307
+        },
+        "solarheat__cc0__dP_60": {
+            "frozen": false,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.049852414049509734
+        },
+        "solarheat__cc0__dP_75": {
+            "frozen": false,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.07065384062229474
+        },
+        "solarheat__cc0__dP_90": {
+            "frozen": false,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.092965710077585
+        },
+        "solarheat__cc0__tau": {
+            "frozen": true,
+            "max": 365.25,
+            "min": 365.0,
+            "val": 365.0
+        },
+        "solarheat__tcylaft6__P_120": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.0157796366263856
+        },
+        "solarheat__tcylaft6__P_130": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.0115163472320874
+        },
+        "solarheat__tcylaft6__P_140": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.0521042811001025
+        },
+        "solarheat__tcylaft6__P_150": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.1353665595733407
+        },
+        "solarheat__tcylaft6__P_155": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.2004018098886413
+        },
+        "solarheat__tcylaft6__P_160": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.3100616673004566
+        },
+        "solarheat__tcylaft6__P_170": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.4459379579437883
+        },
+        "solarheat__tcylaft6__P_45": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.71112386045744
+        },
+        "solarheat__tcylaft6__P_60": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.511689075329988
+        },
+        "solarheat__tcylaft6__P_75": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.33558170544472
+        },
+        "solarheat__tcylaft6__P_90": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.175796793338405
+        },
+        "solarheat__tcylaft6__ampl": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.1277344381214333
+        },
+        "solarheat__tcylaft6__bias": {
+            "frozen": true,
+            "max": 2.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_120": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_130": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_140": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_150": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_155": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_160": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_170": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_45": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_60": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_75": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_90": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__tau": {
+            "frozen": true,
+            "max": 365.25,
+            "min": 365.0,
+            "val": 365.0
+        },
+        "solarheat_off_nom_roll__cc0__P_minus_y": {
+            "frozen": true,
+            "max": 2,
+            "min": -2,
+            "val": 0.5317010196538007
+        },
+        "solarheat_off_nom_roll__cc0__P_plus_y": {
+            "frozen": true,
+            "max": 2,
+            "min": -2,
+            "val": 0.409045455469855
+        },
+        "solarheat_off_nom_roll__tcylaft6__P_minus_y": {
+            "frozen": true,
+            "max": 2,
+            "min": -2,
+            "val": 0.1403704986365521
+        },
+        "solarheat_off_nom_roll__tcylaft6__P_plus_y": {
+            "frozen": true,
+            "max": 2,
+            "min": -2,
+            "val": 0.10983206606570352
+        },
+        "tstart": "2014:001:12:02:32.816",
+        "tstop": "2018:150:11:53:58.816"
+    },
+    {
+        "coupling__tcylaft6__cc0__tau": {
+            "frozen": false,
+            "max": 200.0,
+            "min": 2.0,
+            "val": 40.849155762646305
+        },
+        "date": "2018:258:16:43:15.517",
+        "final_eval_num": "31031",
+        "fit_stat": 1663369.8057550776,
+        "heatsink__cc0__T": {
+            "frozen": true,
+            "max": 100.0,
+            "min": -300.0,
+            "val": 12.004172208223716
+        },
+        "heatsink__cc0__tau": {
+            "frozen": true,
+            "max": 400.0,
+            "min": 2.0,
+            "val": 109.41360686503907
+        },
+        "heatsink__tcylaft6__T": {
+            "frozen": true,
+            "max": 100.0,
+            "min": -300.0,
+            "val": 59.458949796024164
+        },
+        "heatsink__tcylaft6__tau": {
+            "frozen": true,
+            "max": 400.0,
+            "min": 2.0,
+            "val": 20.01164719992392
+        },
+        "method": "moncar",
+        "solarheat__cc0__P_120": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": 0.48007540020521394
+        },
+        "solarheat__cc0__P_130": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": 0.3174504983338686
+        },
+        "solarheat__cc0__P_140": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": 0.14813344412623222
+        },
+        "solarheat__cc0__P_150": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -0.04107404235517799
+        },
+        "solarheat__cc0__P_155": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -0.15860067843660164
+        },
+        "solarheat__cc0__P_160": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -0.1910536698701293
+        },
+        "solarheat__cc0__P_170": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -0.2485174828820357
+        },
+        "solarheat__cc0__P_45": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": 0.5647536356352473
+        },
+        "solarheat__cc0__P_60": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": 0.5804091477648061
+        },
+        "solarheat__cc0__P_75": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": 0.6254990330216804
+        },
+        "solarheat__cc0__P_90": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": 0.6143966432859227
+        },
+        "solarheat__cc0__ampl": {
+            "frozen": false,
+            "max": 1.0,
+            "min": -1.0,
+            "val": -0.002079798489273534
+        },
+        "solarheat__cc0__bias": {
+            "frozen": true,
+            "max": 2.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_120": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.11044191434169756
+        },
+        "solarheat__cc0__dP_130": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.11423189810784957
+        },
+        "solarheat__cc0__dP_140": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.1142566010757129
+        },
+        "solarheat__cc0__dP_150": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.11178434804147101
+        },
+        "solarheat__cc0__dP_155": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.10237434478244646
+        },
+        "solarheat__cc0__dP_160": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.11927281130414952
+        },
+        "solarheat__cc0__dP_170": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": -0.06859062563059512
+        },
+        "solarheat__cc0__dP_45": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.04419124736909307
+        },
+        "solarheat__cc0__dP_60": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.049852414049509734
+        },
+        "solarheat__cc0__dP_75": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.07065384062229474
+        },
+        "solarheat__cc0__dP_90": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.092965710077585
+        },
+        "solarheat__cc0__tau": {
+            "frozen": true,
+            "max": 365.25,
+            "min": 365.0,
+            "val": 365.0
+        },
+        "solarheat__tcylaft6__P_120": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.0157796366263856
+        },
+        "solarheat__tcylaft6__P_130": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.0115163472320874
+        },
+        "solarheat__tcylaft6__P_140": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.0521042811001025
+        },
+        "solarheat__tcylaft6__P_150": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.1353665595733407
+        },
+        "solarheat__tcylaft6__P_155": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.2004018098886413
+        },
+        "solarheat__tcylaft6__P_160": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.3100616673004566
+        },
+        "solarheat__tcylaft6__P_170": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.4459379579437883
+        },
+        "solarheat__tcylaft6__P_45": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.71112386045744
+        },
+        "solarheat__tcylaft6__P_60": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.511689075329988
+        },
+        "solarheat__tcylaft6__P_75": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.33558170544472
+        },
+        "solarheat__tcylaft6__P_90": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.175796793338405
+        },
+        "solarheat__tcylaft6__ampl": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.1277344381214333
+        },
+        "solarheat__tcylaft6__bias": {
+            "frozen": true,
+            "max": 2.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_120": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_130": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_140": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_150": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_155": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_160": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_170": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_45": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_60": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_75": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_90": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__tau": {
+            "frozen": true,
+            "max": 365.25,
+            "min": 365.0,
+            "val": 365.0
+        },
+        "solarheat_off_nom_roll__cc0__P_minus_y": {
+            "frozen": false,
+            "max": 2,
+            "min": -2,
+            "val": 0.5284233489138168
+        },
+        "solarheat_off_nom_roll__cc0__P_plus_y": {
+            "frozen": false,
+            "max": 2,
+            "min": -2,
+            "val": 0.3915737954538192
+        },
+        "solarheat_off_nom_roll__tcylaft6__P_minus_y": {
+            "frozen": false,
+            "max": 2,
+            "min": -2,
+            "val": 0.08988058914147325
+        },
+        "solarheat_off_nom_roll__tcylaft6__P_plus_y": {
+            "frozen": false,
+            "max": 2,
+            "min": -2,
+            "val": 0.1811242047246876
+        },
+        "tstart": "2014:001:12:02:32.816",
+        "tstop": "2018:150:11:53:58.816"
+    },
+    {
+        "coupling__tcylaft6__cc0__tau": {
+            "frozen": false,
+            "max": 200.0,
+            "min": 2.0,
+            "val": 41.24153028565394
+        },
+        "date": "2018:258:17:06:56.862",
+        "final_eval_num": "32419",
+        "fit_stat": 1641539.3430748277,
+        "heatsink__cc0__T": {
+            "frozen": true,
+            "max": 100.0,
+            "min": -300.0,
+            "val": 12.004172208223716
+        },
+        "heatsink__cc0__tau": {
+            "frozen": true,
+            "max": 400.0,
+            "min": 2.0,
+            "val": 109.41360686503907
+        },
+        "heatsink__tcylaft6__T": {
+            "frozen": true,
+            "max": 100.0,
+            "min": -300.0,
+            "val": 59.458949796024164
+        },
+        "heatsink__tcylaft6__tau": {
+            "frozen": true,
+            "max": 400.0,
+            "min": 2.0,
+            "val": 20.01164719992392
+        },
+        "method": "moncar",
+        "solarheat__cc0__P_120": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.48007540020521394
+        },
+        "solarheat__cc0__P_130": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.3174504983338686
+        },
+        "solarheat__cc0__P_140": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.14813344412623222
+        },
+        "solarheat__cc0__P_150": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -0.04107404235517799
+        },
+        "solarheat__cc0__P_155": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -0.15860067843660164
+        },
+        "solarheat__cc0__P_160": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -0.1910536698701293
+        },
+        "solarheat__cc0__P_170": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -0.2485174828820357
+        },
+        "solarheat__cc0__P_45": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.5647536356352473
+        },
+        "solarheat__cc0__P_60": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.5804091477648061
+        },
+        "solarheat__cc0__P_75": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.6254990330216804
+        },
+        "solarheat__cc0__P_90": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.6143966432859227
+        },
+        "solarheat__cc0__ampl": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": -0.002079798489273534
+        },
+        "solarheat__cc0__bias": {
+            "frozen": true,
+            "max": 2.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_120": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.11044191434169756
+        },
+        "solarheat__cc0__dP_130": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.11423189810784957
+        },
+        "solarheat__cc0__dP_140": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.1142566010757129
+        },
+        "solarheat__cc0__dP_150": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.11178434804147101
+        },
+        "solarheat__cc0__dP_155": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.10237434478244646
+        },
+        "solarheat__cc0__dP_160": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.11927281130414952
+        },
+        "solarheat__cc0__dP_170": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": -0.06859062563059512
+        },
+        "solarheat__cc0__dP_45": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.04419124736909307
+        },
+        "solarheat__cc0__dP_60": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.049852414049509734
+        },
+        "solarheat__cc0__dP_75": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.07065384062229474
+        },
+        "solarheat__cc0__dP_90": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.092965710077585
+        },
+        "solarheat__cc0__tau": {
+            "frozen": true,
+            "max": 365.25,
+            "min": 365.0,
+            "val": 365.0
+        },
+        "solarheat__tcylaft6__P_120": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -0.9942482263030008
+        },
+        "solarheat__tcylaft6__P_130": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -1.012226846830412
+        },
+        "solarheat__tcylaft6__P_140": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -1.0548405343304976
+        },
+        "solarheat__tcylaft6__P_150": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -1.144131257365775
+        },
+        "solarheat__tcylaft6__P_155": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -1.2109473833681923
+        },
+        "solarheat__tcylaft6__P_160": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -1.3267714043863885
+        },
+        "solarheat__tcylaft6__P_170": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -1.469914699887023
+        },
+        "solarheat__tcylaft6__P_45": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -1.6983656719074673
+        },
+        "solarheat__tcylaft6__P_60": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -1.5035392630003266
+        },
+        "solarheat__tcylaft6__P_75": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -1.3204723055088412
+        },
+        "solarheat__tcylaft6__P_90": {
+            "frozen": false,
+            "max": 4,
+            "min": -3,
+            "val": -1.1525415460886825
+        },
+        "solarheat__tcylaft6__ampl": {
+            "frozen": false,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.1279891510392162
+        },
+        "solarheat__tcylaft6__bias": {
+            "frozen": true,
+            "max": 2.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_120": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_130": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_140": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_150": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_155": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_160": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_170": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_45": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_60": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_75": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_90": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__tau": {
+            "frozen": true,
+            "max": 365.25,
+            "min": 365.0,
+            "val": 365.0
+        },
+        "solarheat_off_nom_roll__cc0__P_minus_y": {
+            "frozen": true,
+            "max": 2,
+            "min": -2,
+            "val": 0.5284233489138168
+        },
+        "solarheat_off_nom_roll__cc0__P_plus_y": {
+            "frozen": true,
+            "max": 2,
+            "min": -2,
+            "val": 0.3915737954538192
+        },
+        "solarheat_off_nom_roll__tcylaft6__P_minus_y": {
+            "frozen": false,
+            "max": 2,
+            "min": -2,
+            "val": 0.1514565967421072
+        },
+        "solarheat_off_nom_roll__tcylaft6__P_plus_y": {
+            "frozen": false,
+            "max": 2,
+            "min": -2,
+            "val": 0.13958192695333319
+        },
+        "tstart": "2014:001:12:02:32.816",
+        "tstop": "2018:150:11:53:58.816"
+    },
+    {
+        "coupling__tcylaft6__cc0__tau": {
+            "frozen": false,
+            "max": 200.0,
+            "min": 2.0,
+            "val": 44.506318152401086
+        },
+        "date": "2018:258:17:13:27.211",
+        "final_eval_num": "8945",
+        "fit_stat": 1559361.4002801075,
+        "heatsink__cc0__T": {
+            "frozen": false,
+            "max": 100.0,
+            "min": -300.0,
+            "val": 11.079743567364366
+        },
+        "heatsink__cc0__tau": {
+            "frozen": false,
+            "max": 400.0,
+            "min": 2.0,
+            "val": 119.0566092719493
+        },
+        "heatsink__tcylaft6__T": {
+            "frozen": false,
+            "max": 100.0,
+            "min": -300.0,
+            "val": 58.96657399218693
+        },
+        "heatsink__tcylaft6__tau": {
+            "frozen": false,
+            "max": 400.0,
+            "min": 2.0,
+            "val": 20.093185156334666
+        },
+        "method": "moncar",
+        "solarheat__cc0__P_120": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.48007540020521394
+        },
+        "solarheat__cc0__P_130": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.3174504983338686
+        },
+        "solarheat__cc0__P_140": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.14813344412623222
+        },
+        "solarheat__cc0__P_150": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -0.04107404235517799
+        },
+        "solarheat__cc0__P_155": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -0.15860067843660164
+        },
+        "solarheat__cc0__P_160": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -0.1910536698701293
+        },
+        "solarheat__cc0__P_170": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -0.2485174828820357
+        },
+        "solarheat__cc0__P_45": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.5647536356352473
+        },
+        "solarheat__cc0__P_60": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.5804091477648061
+        },
+        "solarheat__cc0__P_75": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.6254990330216804
+        },
+        "solarheat__cc0__P_90": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": 0.6143966432859227
+        },
+        "solarheat__cc0__ampl": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": -0.002079798489273534
+        },
+        "solarheat__cc0__bias": {
+            "frozen": true,
+            "max": 2.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__cc0__dP_120": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.11044191434169756
+        },
+        "solarheat__cc0__dP_130": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.11423189810784957
+        },
+        "solarheat__cc0__dP_140": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.1142566010757129
+        },
+        "solarheat__cc0__dP_150": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.11178434804147101
+        },
+        "solarheat__cc0__dP_155": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.10237434478244646
+        },
+        "solarheat__cc0__dP_160": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.11927281130414952
+        },
+        "solarheat__cc0__dP_170": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": -0.06859062563059512
+        },
+        "solarheat__cc0__dP_45": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.04419124736909307
+        },
+        "solarheat__cc0__dP_60": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.049852414049509734
+        },
+        "solarheat__cc0__dP_75": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.07065384062229474
+        },
+        "solarheat__cc0__dP_90": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.092965710077585
+        },
+        "solarheat__cc0__tau": {
+            "frozen": true,
+            "max": 365.25,
+            "min": 365.0,
+            "val": 365.0
+        },
+        "solarheat__tcylaft6__P_120": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -0.9942482263030008
+        },
+        "solarheat__tcylaft6__P_130": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.012226846830412
+        },
+        "solarheat__tcylaft6__P_140": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.0548405343304976
+        },
+        "solarheat__tcylaft6__P_150": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.144131257365775
+        },
+        "solarheat__tcylaft6__P_155": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.2109473833681923
+        },
+        "solarheat__tcylaft6__P_160": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.3267714043863885
+        },
+        "solarheat__tcylaft6__P_170": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.469914699887023
+        },
+        "solarheat__tcylaft6__P_45": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.6983656719074673
+        },
+        "solarheat__tcylaft6__P_60": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.5035392630003266
+        },
+        "solarheat__tcylaft6__P_75": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.3204723055088412
+        },
+        "solarheat__tcylaft6__P_90": {
+            "frozen": true,
+            "max": 4,
+            "min": -3,
+            "val": -1.1525415460886825
+        },
+        "solarheat__tcylaft6__ampl": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.1279891510392162
+        },
+        "solarheat__tcylaft6__bias": {
+            "frozen": true,
+            "max": 2.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_120": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_130": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_140": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_150": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_155": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_160": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_170": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_45": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_60": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_75": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__dP_90": {
+            "frozen": true,
+            "max": 1.0,
+            "min": -1.0,
+            "val": 0.0
+        },
+        "solarheat__tcylaft6__tau": {
+            "frozen": true,
+            "max": 365.25,
+            "min": 365.0,
+            "val": 365.0
+        },
+        "solarheat_off_nom_roll__cc0__P_minus_y": {
+            "frozen": true,
+            "max": 2,
+            "min": -2,
+            "val": 0.5284233489138168
+        },
+        "solarheat_off_nom_roll__cc0__P_plus_y": {
+            "frozen": true,
+            "max": 2,
+            "min": -2,
+            "val": 0.3915737954538192
+        },
+        "solarheat_off_nom_roll__tcylaft6__P_minus_y": {
+            "frozen": true,
+            "max": 2,
+            "min": -2,
+            "val": 0.1514565967421072
+        },
+        "solarheat_off_nom_roll__tcylaft6__P_plus_y": {
+            "frozen": true,
+            "max": 2,
+            "min": -2,
+            "val": 0.13958192695333319
+        },
+        "tstart": "2014:001:12:02:32.816",
+        "tstop": "2018:150:11:53:58.816"
     }
 ]

--- a/chandra_models/xija/tcylaft6/tcylaft6_fit_script.py
+++ b/chandra_models/xija/tcylaft6/tcylaft6_fit_script.py
@@ -1,53 +1,204 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+import xija
+import sys
+from os.path import expanduser
+import re
+
+home = expanduser("~")
+addthispath = home + '/AXAFLIB/xijafit/'
+sys.path.insert(0, addthispath)
 import xijafit
 
-newmodel = xijafit.XijaFit('tcylaft6_model_spec_roll_base.json', set_data_exprs=(u'tcylaft6_0=22.0',),
-   start='2014:300', stop='2016:300', quiet=False, name='tcylaft6')
 
+class XijaFitPatched(xijafit.XijaFit):
+
+
+    def thaw_solarheat_p(self, msid):
+        """Thaw all solarheat "P" parameters.
+        """
+        p = 'solarheat__{}__P_\d+'.format(msid.lower())
+        found = False
+        for par in self.model.pars:
+            if re.match(p, par.full_name):
+                par['frozen'] = False
+                found = True
+        if not found:
+            print('Solarheat "P" parameters not found')
+
+    def thaw_solarheat_dp(self, msid):
+        """Thaw all solarheat "dP" parameters.
+        """
+        p = 'solarheat__{}__dP_\d+'.format(msid.lower())
+        found = False
+        for par in self.model.pars:
+            if re.match(p, par.full_name):
+                par['frozen'] = False
+                found = True
+        if not found:
+            print('Solarheat "dP" parameters not found')
+
+stars = '*'*80
+n = 0
+
+newmodel = XijaFitPatched('tcylaft6_model_spec.json', start='2014:001', stop='2018:150', set_data_exprs=(u'cc0=30.0',), quiet=False, name='tcylaft6')
+newmodel.zero_solarheat_dp()
+
+#-----------------------------------------------------------------------------
+# Initial Solarheat Fit
+
+n = n + 1
+print('{}\nStep {}\n{}'.format(stars, n, stars))
 newmodel.freeze_all()
-newmodel.thaw_solarheat_p()
+newmodel.thaw_solarheat_p('cc0')
+newmodel.thaw_param(u'solarheat__cc0__ampl')
+newmodel.thaw_param(u'coupling__tcylaft6__cc0')
+newmodel.fit(method='moncar')
+
+n = n + 1
+print('{}\nStep {}\n{}'.format(stars, n, stars))
+newmodel.freeze_all()
+newmodel.thaw_solarheat_p('tcylaft6')
+newmodel.thaw_param(u'solarheat__tcylaft6__ampl')
+newmodel.thaw_param(u'coupling__tcylaft6__cc0')
+newmodel.fit(method='moncar')
+
+n = n + 1
+print('{}\nStep {}\n{}'.format(stars, n, stars))
+newmodel.freeze_all()
+newmodel.thaw_param(u'heatsink__cc0__tau')
+newmodel.thaw_param(u'heatsink__cc0__T')
+newmodel.thaw_param(u'heatsink__tcylaft6__tau')
+newmodel.thaw_param(u'heatsink__tcylaft6__T')
+newmodel.thaw_param(u'coupling__tcylaft6__cc0')
+newmodel.fit(method='moncar')
+
+n = n + 1
+print('{}\nStep {}\n{}'.format(stars, n, stars))
+newmodel.freeze_all()
+newmodel.thaw_solarheat_p('cc0')
+newmodel.thaw_param(u'solarheat__cc0__ampl')
+newmodel.thaw_param(u'coupling__tcylaft6__cc0')
+newmodel.thaw_param(u'solarheat_off_nom_roll__cc0__P_plus_y')
+newmodel.thaw_param(u'solarheat_off_nom_roll__cc0__P_minus_y')
+newmodel.fit(method='moncar')
+
+n = n + 1
+print('{}\nStep {}\n{}'.format(stars, n, stars))
+newmodel.freeze_all()
+newmodel.thaw_solarheat_p('tcylaft6')
+newmodel.thaw_param(u'solarheat__tcylaft6__ampl')
+newmodel.thaw_param(u'coupling__tcylaft6__cc0')
+newmodel.thaw_param(u'solarheat_off_nom_roll__tcylaft6__P_plus_y')
+newmodel.thaw_param(u'solarheat_off_nom_roll__tcylaft6__P_minus_y')
+newmodel.fit(method='moncar')
+
+#-----------------------------------------------------------------------------
+# Initial DP Solarheat Fit
+
+n = n + 1
+print('{}\nStep {}\n{}'.format(stars, n, stars))
+newmodel.freeze_all()
+newmodel.thaw_solarheat_dp('cc0')
+newmodel.thaw_param(u'solarheat__cc0__ampl')
+newmodel.fit(method='moncar')
+
+#-----------------------------------------------------------------------------
+# Second Solarheat Fit
+
+n = n + 1
+print('{}\nStep {}\n{}'.format(stars, n, stars))
+newmodel.freeze_all()
+newmodel.thaw_solarheat_p('cc0')
+newmodel.thaw_param(u'solarheat__cc0__ampl')
+newmodel.thaw_param(u'coupling__tcylaft6__cc0')
+newmodel.thaw_param(u'solarheat_off_nom_roll__cc0__P_plus_y')
+newmodel.thaw_param(u'solarheat_off_nom_roll__cc0__P_minus_y')
+newmodel.fit(method='moncar')
+
+n = n + 1
+print('{}\nStep {}\n{}'.format(stars, n, stars))
+newmodel.freeze_all()
+newmodel.thaw_solarheat_p('tcylaft6')
+newmodel.thaw_param(u'solarheat__tcylaft6__ampl')
+newmodel.thaw_param(u'coupling__tcylaft6__cc0')
+newmodel.thaw_param(u'solarheat_off_nom_roll__tcylaft6__P_plus_y')
+newmodel.thaw_param(u'solarheat_off_nom_roll__tcylaft6__P_minus_y')
+newmodel.fit(method='moncar')
+
+n = n + 1
+print('{}\nStep {}\n{}'.format(stars, n, stars))
+newmodel.freeze_all()
+newmodel.thaw_param(u'heatsink__cc0__tau')
+newmodel.thaw_param(u'heatsink__cc0__T')
+newmodel.thaw_param(u'heatsink__tcylaft6__tau')
+newmodel.thaw_param(u'heatsink__tcylaft6__T')
+newmodel.thaw_param(u'coupling__tcylaft6__cc0')
+newmodel.fit(method='moncar')
+
+#-----------------------------------------------------------------------------
+# Second DP Solarheat Fit
+n = n + 1
+print('{}\nStep {}\n{}'.format(stars, n, stars))
+newmodel.freeze_all()
+newmodel.thaw_solarheat_dp('cc0')
+newmodel.thaw_param(u'solarheat__cc0__ampl')
+newmodel.fit(method='moncar')
+
+#-----------------------------------------------------------------------------
+# Third DP Solarheat Fit
+
+n = n + 1
+print('{}\nStep {}\n{}'.format(stars, n, stars))
+newmodel.freeze_all()
+newmodel.thaw_solarheat_dp('cc0')
+newmodel.thaw_param(u'solarheat__cc0__ampl')
+newmodel.fit(method='moncar')
+
+#-----------------------------------------------------------------------------
+# Third Solarheat Fit
+
+n = n + 1
+print('{}\nStep {}\n{}'.format(stars, n, stars))
+newmodel.freeze_all()
+newmodel.thaw_solarheat_p('cc0')
 newmodel.thaw_solarheat_roll()
-newmodel.thaw_param(u'coupling__tcylaft6__tcylaft6_0__tau')
-newmodel.thaw_param(u'solarheat__tcylaft6_0__ampl')
+newmodel.thaw_param(u'solarheat__cc0__ampl')
+newmodel.thaw_param(u'coupling__tcylaft6__cc0')
+newmodel.thaw_param(u'solarheat_off_nom_roll__cc0__P_plus_y')
+newmodel.thaw_param(u'solarheat_off_nom_roll__cc0__P_minus_y')
 newmodel.fit(method='moncar')
 
+n = n + 1
+print('{}\nStep {}\n{}'.format(stars, n, stars))
 newmodel.freeze_all()
-newmodel.thaw_param(u'heatsink__tcylaft6_0__T')
-newmodel.thaw_param(u'heatsink__tcylaft6_0__tau')
+newmodel.thaw_solarheat_p('tcylaft6')
+newmodel.thaw_param(u'solarheat__tcylaft6__ampl')
+newmodel.thaw_param(u'coupling__tcylaft6__cc0')
+newmodel.thaw_param(u'solarheat_off_nom_roll__tcylaft6__P_plus_y')
+newmodel.thaw_param(u'solarheat_off_nom_roll__tcylaft6__P_minus_y')
 newmodel.fit(method='moncar')
 
+n = n + 1
+print('{}\nStep {}\n{}'.format(stars, n, stars))
 newmodel.freeze_all()
-newmodel.set_range('solarheat__tcylaft6_0__dP_45', -0.5, 0.5)
-newmodel.set_range('solarheat__tcylaft6_0__dP_60', -0.5, 0.5)
-newmodel.set_range('solarheat__tcylaft6_0__dP_80', -0.5, 0.5)
-newmodel.set_range('solarheat__tcylaft6_0__dP_90', -0.5, 0.5)
-newmodel.set_range('solarheat__tcylaft6_0__dP_100', -0.5, 0.5)
-newmodel.set_range('solarheat__tcylaft6_0__dP_110', -0.5, 0.5)
-newmodel.set_range('solarheat__tcylaft6_0__dP_120', -0.5, 0.5)
-newmodel.set_range('solarheat__tcylaft6_0__dP_130', -0.5, 0.5)
-newmodel.set_range('solarheat__tcylaft6_0__dP_140', -0.5, 0.5)
-newmodel.set_range('solarheat__tcylaft6_0__dP_150', -0.5, 0.5)
-newmodel.set_range('solarheat__tcylaft6_0__dP_160', -0.5, 0.5)
-newmodel.set_range('solarheat__tcylaft6_0__dP_180', -0.5, 0.5)
-newmodel.thaw_solarheat_dp()
-newmodel.thaw_param(u'solarheat__tcylaft6_0__ampl')
+newmodel.thaw_param(u'heatsink__cc0__tau')
+newmodel.thaw_param(u'heatsink__cc0__T')
+newmodel.thaw_param(u'heatsink__tcylaft6__tau')
+newmodel.thaw_param(u'heatsink__tcylaft6__T')
+newmodel.thaw_param(u'coupling__tcylaft6__cc0')
 newmodel.fit(method='moncar')
 
-newmodel.update_fit_times(start='2013:300', stop='2016:300')
-# The next three lines were run but are redundant with the following group of fitting commands.
-newmodel.freeze_all()
-newmodel.thaw_solarheat_p()
-newmodel.fit(method='moncar')
-
-newmodel.freeze_all()
-newmodel.thaw_solarheat_p()
-newmodel.thaw_solarheat_roll()
-newmodel.thaw_param(u'coupling__tcylaft6__tcylaft6_0__tau')
-newmodel.fit(method='moncar')
-
-newmodel.freeze_all()
-newmodel.thaw_solarheat_dp()
-newmodel.fit(method='moncar')
+# These changes were made in the Jupyter notebook:
+#
+# ind = names.index('solarheat__cc0__P_160')
+# newmodel.model.pars[ind]['val'] = -0.25
+# ind = names.index('solarheat__cc0__P_170')
+# newmodel.model.pars[ind]['val'] = -0.4
+# ind = names.index('solarheat__cc0__dP_170')
+# newmodel.model.pars[ind]['val'] = 0.11
 
 newmodel.write_spec_file()
 newmodel.write_snapshots_file()
+
+

--- a/chandra_models/xija/tcylaft6/tcylaft6_spec.json
+++ b/chandra_models/xija/tcylaft6/tcylaft6_spec.json
@@ -1,447 +1,781 @@
 {
     "comps": [
         {
-            "class_name": "Node", 
+            "class_name": "Node",
             "init_args": [
-                "tcylaft6_0"
-            ], 
+                "cc0"
+            ],
             "init_kwargs": {
                 "sigma": 100000.0
-            }, 
-            "name": "tcylaft6_0"
-        }, 
+            },
+            "name": "cc0"
+        },
         {
-            "class_name": "Pitch", 
-            "init_args": [], 
-            "init_kwargs": {}, 
-            "name": "pitch"
-        }, 
-        {
-            "class_name": "Eclipse", 
-            "init_args": [], 
-            "init_kwargs": {}, 
-            "name": "eclipse"
-        }, 
-        {
-            "class_name": "HeatSink", 
-            "init_args": [
-                "tcylaft6_0"
-            ], 
-            "init_kwargs": {
-                "T": 20.0, 
-                "tau": 30.0
-            }, 
-            "name": "heatsink__tcylaft6_0"
-        }, 
-        {
-            "class_name": "SolarHeat", 
-            "init_args": [
-                "tcylaft6_0", 
-                "pitch", 
-                "eclipse", 
-                [
-                    45, 
-                    60, 
-                    80, 
-                    90, 
-                    100, 
-                    110, 
-                    120, 
-                    130, 
-                    140, 
-                    150, 
-                    160, 
-                    180
-                ], 
-                [
-                    0.1, 
-                    0.1, 
-                    0.1, 
-                    0.1, 
-                    0.1, 
-                    0.1, 
-                    0.1, 
-                    0.1, 
-                    0.1, 
-                    0.1, 
-                    0.1, 
-                    0.1
-                ]
-            ], 
-            "init_kwargs": {
-                "ampl": 0.003851, 
-                "epoch": "2015:117", 
-                "tau": 365, 
-                "var_func": "linear"
-            }, 
-            "name": "solarheat__tcylaft6_0"
-        }, 
-        {
-            "class_name": "Node", 
+            "class_name": "Node",
             "init_args": [
                 "tcylaft6"
-            ], 
-            "init_kwargs": {}, 
+            ],
+            "init_kwargs": {},
             "name": "tcylaft6"
-        }, 
+        },
         {
-            "class_name": "Coupling", 
+            "class_name": "Pitch",
+            "init_args": [],
+            "init_kwargs": {},
+            "name": "pitch"
+        },
+        {
+            "class_name": "Eclipse",
+            "init_args": [],
+            "init_kwargs": {},
+            "name": "eclipse"
+        },
+        {
+            "class_name": "Roll",
+            "init_args": [],
+            "init_kwargs": {},
+            "name": "roll"
+        },
+        {
+            "class_name": "SolarHeat",
             "init_args": [
-                "tcylaft6", 
-                "tcylaft6_0"
-            ], 
+                "cc0",
+                "pitch",
+                "eclipse",
+                [
+                    45,
+                    60,
+                    75,
+                    90,
+                    120,
+                    130,
+                    140,
+                    150,
+                    155,
+                    160,
+                    170
+                ],
+                [
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0
+                ]
+            ],
+            "init_kwargs": {
+                "ampl": 0.003851,
+                "epoch": "2016:150",
+                "tau": 365,
+                "var_func": "linear"
+            },
+            "name": "solarheat__cc0"
+        },
+        {
+            "class_name": "SolarHeat",
+            "init_args": [
+                "tcylaft6",
+                "pitch",
+                "eclipse",
+                [
+                    45,
+                    60,
+                    75,
+                    90,
+                    120,
+                    130,
+                    140,
+                    150,
+                    155,
+                    160,
+                    170
+                ],
+                [
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0
+                ]
+            ],
+            "init_kwargs": {
+                "ampl": 0.003851,
+                "epoch": "2016:150",
+                "tau": 365,
+                "var_func": "linear"
+            },
+            "name": "solarheat__tcylaft6"
+        },
+        {
+            "class_name": "HeatSink",
+            "init_args": [
+                "cc0"
+            ],
+            "init_kwargs": {
+                "T": 20.0,
+                "tau": 30.0
+            },
+            "name": "heatsink__cc0"
+        },
+        {
+            "class_name": "HeatSink",
+            "init_args": [
+                "tcylaft6"
+            ],
+            "init_kwargs": {
+                "T": 20.0,
+                "tau": 30.0
+            },
+            "name": "heatsink__tcylaft6"
+        },
+        {
+            "class_name": "Coupling",
+            "init_args": [
+                "tcylaft6",
+                "cc0"
+            ],
             "init_kwargs": {
                 "tau": 100.0
-            }, 
-            "name": "coupling__tcylaft6__tcylaft6_0"
-        }, 
+            },
+            "name": "coupling__tcylaft6__cc0"
+        },
         {
-            "class_name": "Roll", 
-            "init_args": [], 
-            "init_kwargs": {}, 
-            "name": "roll"
-        }, 
+            "class_name": "SolarHeatOffNomRoll",
+            "init_args": [
+                "cc0"
+            ],
+            "init_kwargs": {
+                "P_minus_y": 0.0,
+                "P_plus_y": 0.0,
+                "eclipse_comp": "eclipse",
+                "pitch_comp": "pitch",
+                "roll_comp": "roll"
+            },
+            "name": "solarheat_off_nom_roll__cc0"
+        },
         {
-            "class_name": "SolarHeatOffNomRoll", 
+            "class_name": "SolarHeatOffNomRoll",
             "init_args": [
                 "tcylaft6"
-            ], 
+            ],
             "init_kwargs": {
-                "P_minus_y": 0.0, 
-                "P_plus_y": 0.0, 
-                "eclipse_comp": "eclipse", 
-                "pitch_comp": "pitch", 
+                "P_minus_y": 0.0,
+                "P_plus_y": 0.0,
+                "eclipse_comp": "eclipse",
+                "pitch_comp": "pitch",
                 "roll_comp": "roll"
-            }, 
+            },
             "name": "solarheat_off_nom_roll__tcylaft6"
         }
-    ], 
-    "datestart": "2013:300:12:04:32.816", 
-    "datestop": "2016:300:11:53:27.816", 
-    "dt": 328.0, 
-    "mval_names": [], 
-    "name": "tcylaft6", 
+    ],
+    "datestart": "2014:150:12:09:12.816",
+    "datestop": "2018:150:11:48:30.816",
+    "dt": 328.0,
+    "mval_names": [],
+    "name": "tcylaft6",
     "pars": [
         {
-            "comp_name": "heatsink__tcylaft6_0", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "heatsink__tcylaft6_0__T", 
-            "max": 100.0, 
-            "min": -100.0, 
-            "name": "T", 
-            "val": 5.5699295422179249
-        }, 
+            "comp_name": "solarheat__cc0",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__cc0__P_45",
+            "max": 4,
+            "min": -3,
+            "name": "P_45",
+            "val": 0.5737733974290227
+        },
         {
-            "comp_name": "heatsink__tcylaft6_0", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "heatsink__tcylaft6_0__tau", 
-            "max": 100.0, 
-            "min": 2.0, 
-            "name": "tau", 
-            "val": 20.15042136773322
-        }, 
+            "comp_name": "solarheat__cc0",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__cc0__P_60",
+            "max": 4,
+            "min": -3,
+            "name": "P_60",
+            "val": 0.5905843957231999
+        },
         {
-            "comp_name": "solarheat__tcylaft6_0", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__tcylaft6_0__P_45", 
-            "max": 3.0, 
-            "min": 0.0, 
-            "name": "P_45", 
-            "val": 1.7367913537610207
-        }, 
+            "comp_name": "solarheat__cc0",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__cc0__P_75",
+            "max": 4,
+            "min": -3,
+            "name": "P_75",
+            "val": 0.6399200066345271
+        },
         {
-            "comp_name": "solarheat__tcylaft6_0", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__tcylaft6_0__P_60", 
-            "max": 3.0, 
-            "min": 0.0, 
-            "name": "P_60", 
-            "val": 1.9052084417852613
-        }, 
+            "comp_name": "solarheat__cc0",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__cc0__P_90",
+            "max": 4,
+            "min": -3,
+            "name": "P_90",
+            "val": 0.6333716351635101
+        },
         {
-            "comp_name": "solarheat__tcylaft6_0", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__tcylaft6_0__P_80", 
-            "max": 3.0, 
-            "min": 0.0, 
-            "name": "P_80", 
-            "val": 2.0399587551118676
-        }, 
+            "comp_name": "solarheat__cc0",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__cc0__P_120",
+            "max": 4,
+            "min": -3,
+            "name": "P_120",
+            "val": 0.5026174151678275
+        },
         {
-            "comp_name": "solarheat__tcylaft6_0", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__tcylaft6_0__P_90", 
-            "max": 3.0, 
-            "min": 0.0, 
-            "name": "P_90", 
-            "val": 2.0506214255373116
-        }, 
+            "comp_name": "solarheat__cc0",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__cc0__P_130",
+            "max": 4,
+            "min": -3,
+            "name": "P_130",
+            "val": 0.340766077131136
+        },
         {
-            "comp_name": "solarheat__tcylaft6_0", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__tcylaft6_0__P_100", 
-            "max": 3.0, 
-            "min": 0.0, 
-            "name": "P_100", 
-            "val": 2.083008048907744
-        }, 
+            "comp_name": "solarheat__cc0",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__cc0__P_140",
+            "max": 4,
+            "min": -3,
+            "name": "P_140",
+            "val": 0.17145406498270796
+        },
         {
-            "comp_name": "solarheat__tcylaft6_0", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__tcylaft6_0__P_110", 
-            "max": 3.0, 
-            "min": 0.0, 
-            "name": "P_110", 
-            "val": 2.0653885234151499
-        }, 
+            "comp_name": "solarheat__cc0",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__cc0__P_150",
+            "max": 4,
+            "min": -3,
+            "name": "P_150",
+            "val": -0.01825802670426602
+        },
         {
-            "comp_name": "solarheat__tcylaft6_0", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__tcylaft6_0__P_120", 
-            "max": 3.0, 
-            "min": 0.0, 
-            "name": "P_120", 
-            "val": 1.8805422067103001
-        }, 
+            "comp_name": "solarheat__cc0",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__cc0__P_155",
+            "max": 4,
+            "min": -3,
+            "name": "P_155",
+            "val": -0.13770531433838634
+        },
         {
-            "comp_name": "solarheat__tcylaft6_0", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__tcylaft6_0__P_130", 
-            "max": 3.0, 
-            "min": 0.0, 
-            "name": "P_130", 
-            "val": 1.5915423543126397
-        }, 
+            "comp_name": "solarheat__cc0",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__cc0__P_160",
+            "max": 4,
+            "min": -3,
+            "name": "P_160",
+            "val": -0.25
+        },
         {
-            "comp_name": "solarheat__tcylaft6_0", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__tcylaft6_0__P_140", 
-            "max": 3.0, 
-            "min": 0.0, 
-            "name": "P_140", 
-            "val": 1.2622202698765079
-        }, 
+            "comp_name": "solarheat__cc0",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__cc0__P_170",
+            "max": 4,
+            "min": -3,
+            "name": "P_170",
+            "val": -0.4
+        },
         {
-            "comp_name": "solarheat__tcylaft6_0", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__tcylaft6_0__P_150", 
-            "max": 2.0, 
-            "min": 0.0, 
-            "name": "P_150", 
-            "val": 0.84423924123394822
-        }, 
+            "comp_name": "solarheat__cc0",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__cc0__dP_45",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "dP_45",
+            "val": 0.04419124736909307
+        },
         {
-            "comp_name": "solarheat__tcylaft6_0", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__tcylaft6_0__P_160", 
-            "max": 2.0, 
-            "min": 0.0, 
-            "name": "P_160", 
-            "val": 0.39048601746353478
-        }, 
+            "comp_name": "solarheat__cc0",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__cc0__dP_60",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "dP_60",
+            "val": 0.049852414049509734
+        },
         {
-            "comp_name": "solarheat__tcylaft6_0", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__tcylaft6_0__P_180", 
-            "max": 2.0, 
-            "min": 0.0, 
-            "name": "P_180", 
-            "val": 1.9606928178598484
-        }, 
+            "comp_name": "solarheat__cc0",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__cc0__dP_75",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "dP_75",
+            "val": 0.07065384062229474
+        },
         {
-            "comp_name": "solarheat__tcylaft6_0", 
-            "fmt": "{:.4g}", 
-            "frozen": false, 
-            "full_name": "solarheat__tcylaft6_0__dP_45", 
-            "max": 0.5, 
-            "min": -0.5, 
-            "name": "dP_45", 
-            "val": 0.13633667968033217
-        }, 
+            "comp_name": "solarheat__cc0",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__cc0__dP_90",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "dP_90",
+            "val": 0.092965710077585
+        },
         {
-            "comp_name": "solarheat__tcylaft6_0", 
-            "fmt": "{:.4g}", 
-            "frozen": false, 
-            "full_name": "solarheat__tcylaft6_0__dP_60", 
-            "max": 0.5, 
-            "min": -0.5, 
-            "name": "dP_60", 
-            "val": 0.090896114439088044
-        }, 
+            "comp_name": "solarheat__cc0",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__cc0__dP_120",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "dP_120",
+            "val": 0.11044191434169756
+        },
         {
-            "comp_name": "solarheat__tcylaft6_0", 
-            "fmt": "{:.4g}", 
-            "frozen": false, 
-            "full_name": "solarheat__tcylaft6_0__dP_80", 
-            "max": 0.5, 
-            "min": -0.5, 
-            "name": "dP_80", 
-            "val": 0.1290713098416999
-        }, 
+            "comp_name": "solarheat__cc0",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__cc0__dP_130",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "dP_130",
+            "val": 0.11423189810784957
+        },
         {
-            "comp_name": "solarheat__tcylaft6_0", 
-            "fmt": "{:.4g}", 
-            "frozen": false, 
-            "full_name": "solarheat__tcylaft6_0__dP_90", 
-            "max": 0.5, 
-            "min": -0.5, 
-            "name": "dP_90", 
-            "val": 0.16070368647255273
-        }, 
+            "comp_name": "solarheat__cc0",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__cc0__dP_140",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "dP_140",
+            "val": 0.1142566010757129
+        },
         {
-            "comp_name": "solarheat__tcylaft6_0", 
-            "fmt": "{:.4g}", 
-            "frozen": false, 
-            "full_name": "solarheat__tcylaft6_0__dP_100", 
-            "max": 0.5, 
-            "min": -0.5, 
-            "name": "dP_100", 
-            "val": 0.25059384088956638
-        }, 
+            "comp_name": "solarheat__cc0",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__cc0__dP_150",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "dP_150",
+            "val": 0.11178434804147101
+        },
         {
-            "comp_name": "solarheat__tcylaft6_0", 
-            "fmt": "{:.4g}", 
-            "frozen": false, 
-            "full_name": "solarheat__tcylaft6_0__dP_110", 
-            "max": 0.5, 
-            "min": -0.5, 
-            "name": "dP_110", 
-            "val": 0.24785320978196304
-        }, 
+            "comp_name": "solarheat__cc0",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__cc0__dP_155",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "dP_155",
+            "val": 0.10237434478244646
+        },
         {
-            "comp_name": "solarheat__tcylaft6_0", 
-            "fmt": "{:.4g}", 
-            "frozen": false, 
-            "full_name": "solarheat__tcylaft6_0__dP_120", 
-            "max": 0.5, 
-            "min": -0.5, 
-            "name": "dP_120", 
-            "val": 0.17728335178136606
-        }, 
+            "comp_name": "solarheat__cc0",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__cc0__dP_160",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "dP_160",
+            "val": 0.11927281130414952
+        },
         {
-            "comp_name": "solarheat__tcylaft6_0", 
-            "fmt": "{:.4g}", 
-            "frozen": false, 
-            "full_name": "solarheat__tcylaft6_0__dP_130", 
-            "max": 0.5, 
-            "min": -0.5, 
-            "name": "dP_130", 
-            "val": 0.22183956807374561
-        }, 
+            "comp_name": "solarheat__cc0",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__cc0__dP_170",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "dP_170",
+            "val": 0.11
+        },
         {
-            "comp_name": "solarheat__tcylaft6_0", 
-            "fmt": "{:.4g}", 
-            "frozen": false, 
-            "full_name": "solarheat__tcylaft6_0__dP_140", 
-            "max": 0.5, 
-            "min": -0.5, 
-            "name": "dP_140", 
-            "val": 0.19927551656668463
-        }, 
-        {
-            "comp_name": "solarheat__tcylaft6_0", 
-            "fmt": "{:.4g}", 
-            "frozen": false, 
-            "full_name": "solarheat__tcylaft6_0__dP_150", 
-            "max": 0.5, 
-            "min": -0.5, 
-            "name": "dP_150", 
-            "val": 0.17465518078563746
-        }, 
-        {
-            "comp_name": "solarheat__tcylaft6_0", 
-            "fmt": "{:.4g}", 
-            "frozen": false, 
-            "full_name": "solarheat__tcylaft6_0__dP_160", 
-            "max": 0.5, 
-            "min": -0.5, 
-            "name": "dP_160", 
-            "val": 0.17841576619195629
-        }, 
-        {
-            "comp_name": "solarheat__tcylaft6_0", 
-            "fmt": "{:.4g}", 
-            "frozen": false, 
-            "full_name": "solarheat__tcylaft6_0__dP_180", 
-            "max": 0.5, 
-            "min": -0.5, 
-            "name": "dP_180", 
-            "val": 0.49999711514768763
-        }, 
-        {
-            "comp_name": "solarheat__tcylaft6_0", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__tcylaft6_0__tau", 
-            "max": 365.25, 
-            "min": 365.0, 
-            "name": "tau", 
+            "comp_name": "solarheat__cc0",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__cc0__tau",
+            "max": 365.25,
+            "min": 365.0,
+            "name": "tau",
             "val": 365.0
-        }, 
+        },
         {
-            "comp_name": "solarheat__tcylaft6_0", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__tcylaft6_0__ampl", 
-            "max": 1.0, 
-            "min": -1.0, 
-            "name": "ampl", 
-            "val": 0.081806665515286855
-        }, 
+            "comp_name": "solarheat__cc0",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__cc0__ampl",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "ampl",
+            "val": -0.002079798489273534
+        },
         {
-            "comp_name": "solarheat__tcylaft6_0", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat__tcylaft6_0__bias", 
-            "max": 2.0, 
-            "min": -1.0, 
-            "name": "bias", 
+            "comp_name": "solarheat__cc0",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__cc0__bias",
+            "max": 2.0,
+            "min": -1.0,
+            "name": "bias",
             "val": 0.0
-        }, 
+        },
         {
-            "comp_name": "coupling__tcylaft6__tcylaft6_0", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "coupling__tcylaft6__tcylaft6_0__tau", 
-            "max": 300.0, 
-            "min": 50.0, 
-            "name": "tau", 
-            "val": 125.96144553374542
-        }, 
+            "comp_name": "solarheat__tcylaft6",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__tcylaft6__P_45",
+            "max": 4,
+            "min": -3,
+            "name": "P_45",
+            "val": -1.6983656719074673
+        },
         {
-            "comp_name": "solarheat_off_nom_roll__tcylaft6", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat_off_nom_roll__tcylaft6__P_plus_y", 
-            "max": 1.0, 
-            "min": -1.0, 
-            "name": "P_plus_y", 
-            "val": 0.1313792852252203
-        }, 
+            "comp_name": "solarheat__tcylaft6",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__tcylaft6__P_60",
+            "max": 4,
+            "min": -3,
+            "name": "P_60",
+            "val": -1.5035392630003266
+        },
         {
-            "comp_name": "solarheat_off_nom_roll__tcylaft6", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "solarheat_off_nom_roll__tcylaft6__P_minus_y", 
-            "max": 1.0, 
-            "min": -1.0, 
-            "name": "P_minus_y", 
-            "val": 0.11922566959054204
+            "comp_name": "solarheat__tcylaft6",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__tcylaft6__P_75",
+            "max": 4,
+            "min": -3,
+            "name": "P_75",
+            "val": -1.3204723055088412
+        },
+        {
+            "comp_name": "solarheat__tcylaft6",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__tcylaft6__P_90",
+            "max": 4,
+            "min": -3,
+            "name": "P_90",
+            "val": -1.1525415460886825
+        },
+        {
+            "comp_name": "solarheat__tcylaft6",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__tcylaft6__P_120",
+            "max": 4,
+            "min": -3,
+            "name": "P_120",
+            "val": -0.9942482263030008
+        },
+        {
+            "comp_name": "solarheat__tcylaft6",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__tcylaft6__P_130",
+            "max": 4,
+            "min": -3,
+            "name": "P_130",
+            "val": -1.012226846830412
+        },
+        {
+            "comp_name": "solarheat__tcylaft6",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__tcylaft6__P_140",
+            "max": 4,
+            "min": -3,
+            "name": "P_140",
+            "val": -1.0548405343304976
+        },
+        {
+            "comp_name": "solarheat__tcylaft6",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__tcylaft6__P_150",
+            "max": 4,
+            "min": -3,
+            "name": "P_150",
+            "val": -1.144131257365775
+        },
+        {
+            "comp_name": "solarheat__tcylaft6",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__tcylaft6__P_155",
+            "max": 4,
+            "min": -3,
+            "name": "P_155",
+            "val": -1.2109473833681923
+        },
+        {
+            "comp_name": "solarheat__tcylaft6",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__tcylaft6__P_160",
+            "max": 4,
+            "min": -3,
+            "name": "P_160",
+            "val": -1.3267714043863885
+        },
+        {
+            "comp_name": "solarheat__tcylaft6",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__tcylaft6__P_170",
+            "max": 4,
+            "min": -3,
+            "name": "P_170",
+            "val": -1.469914699887023
+        },
+        {
+            "comp_name": "solarheat__tcylaft6",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__tcylaft6__dP_45",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "dP_45",
+            "val": 0.0
+        },
+        {
+            "comp_name": "solarheat__tcylaft6",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__tcylaft6__dP_60",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "dP_60",
+            "val": 0.0
+        },
+        {
+            "comp_name": "solarheat__tcylaft6",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__tcylaft6__dP_75",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "dP_75",
+            "val": 0.0
+        },
+        {
+            "comp_name": "solarheat__tcylaft6",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__tcylaft6__dP_90",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "dP_90",
+            "val": 0.0
+        },
+        {
+            "comp_name": "solarheat__tcylaft6",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__tcylaft6__dP_120",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "dP_120",
+            "val": 0.0
+        },
+        {
+            "comp_name": "solarheat__tcylaft6",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__tcylaft6__dP_130",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "dP_130",
+            "val": 0.0
+        },
+        {
+            "comp_name": "solarheat__tcylaft6",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__tcylaft6__dP_140",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "dP_140",
+            "val": 0.0
+        },
+        {
+            "comp_name": "solarheat__tcylaft6",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__tcylaft6__dP_150",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "dP_150",
+            "val": 0.0
+        },
+        {
+            "comp_name": "solarheat__tcylaft6",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__tcylaft6__dP_155",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "dP_155",
+            "val": 0.0
+        },
+        {
+            "comp_name": "solarheat__tcylaft6",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__tcylaft6__dP_160",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "dP_160",
+            "val": 0.0
+        },
+        {
+            "comp_name": "solarheat__tcylaft6",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__tcylaft6__dP_170",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "dP_170",
+            "val": 0.0
+        },
+        {
+            "comp_name": "solarheat__tcylaft6",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__tcylaft6__tau",
+            "max": 365.25,
+            "min": 365.0,
+            "name": "tau",
+            "val": 365.0
+        },
+        {
+            "comp_name": "solarheat__tcylaft6",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__tcylaft6__ampl",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "ampl",
+            "val": 0.1279891510392162
+        },
+        {
+            "comp_name": "solarheat__tcylaft6",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__tcylaft6__bias",
+            "max": 2.0,
+            "min": -1.0,
+            "name": "bias",
+            "val": 0.0
+        },
+        {
+            "comp_name": "heatsink__cc0",
+            "fmt": "{:.4g}",
+            "frozen": false,
+            "full_name": "heatsink__cc0__T",
+            "max": 100.0,
+            "min": -300.0,
+            "name": "T",
+            "val": 11.079743567364366
+        },
+        {
+            "comp_name": "heatsink__cc0",
+            "fmt": "{:.4g}",
+            "frozen": false,
+            "full_name": "heatsink__cc0__tau",
+            "max": 400.0,
+            "min": 2.0,
+            "name": "tau",
+            "val": 119.0566092719493
+        },
+        {
+            "comp_name": "heatsink__tcylaft6",
+            "fmt": "{:.4g}",
+            "frozen": false,
+            "full_name": "heatsink__tcylaft6__T",
+            "max": 100.0,
+            "min": -300.0,
+            "name": "T",
+            "val": 58.96657399218693
+        },
+        {
+            "comp_name": "heatsink__tcylaft6",
+            "fmt": "{:.4g}",
+            "frozen": false,
+            "full_name": "heatsink__tcylaft6__tau",
+            "max": 400.0,
+            "min": 2.0,
+            "name": "tau",
+            "val": 20.093185156334666
+        },
+        {
+            "comp_name": "coupling__tcylaft6__cc0",
+            "fmt": "{:.4g}",
+            "frozen": false,
+            "full_name": "coupling__tcylaft6__cc0__tau",
+            "max": 200.0,
+            "min": 2.0,
+            "name": "tau",
+            "val": 44.506318152401086
+        },
+        {
+            "comp_name": "solarheat_off_nom_roll__cc0",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat_off_nom_roll__cc0__P_plus_y",
+            "max": 2,
+            "min": -2,
+            "name": "P_plus_y",
+            "val": 0.3915737954538192
+        },
+        {
+            "comp_name": "solarheat_off_nom_roll__cc0",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat_off_nom_roll__cc0__P_minus_y",
+            "max": 2,
+            "min": -2,
+            "name": "P_minus_y",
+            "val": 0.5284233489138168
+        },
+        {
+            "comp_name": "solarheat_off_nom_roll__tcylaft6",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat_off_nom_roll__tcylaft6__P_plus_y",
+            "max": 2,
+            "min": -2,
+            "name": "P_plus_y",
+            "val": 0.13958192695333319
+        },
+        {
+            "comp_name": "solarheat_off_nom_roll__tcylaft6",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat_off_nom_roll__tcylaft6__P_minus_y",
+            "max": 2,
+            "min": -2,
+            "name": "P_minus_y",
+            "val": 0.1514565967421072
         }
-    ], 
+    ],
     "tlm_code": null
 }


### PR DESCRIPTION
This includes a new model architecture, based off the PLINE04T model, with two solar heat input profiles. The pseudo node is renamed to cc0.