### PR TITLE
Update DPA Parameters

### DIFF
--- a/chandra_models/__init__.py
+++ b/chandra_models/__init__.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from .get_model_spec import *
 
-__version__ = '3.26'
+__version__ = '3.27'
 

--- a/chandra_models/xija/dpa/dpa_spec.json
+++ b/chandra_models/xija/dpa/dpa_spec.json
@@ -136,14 +136,17 @@
             "name": "clocking"
         },
         {
-            "class_name": "SolarHeatHrcOpts",
+            "class_name": "SolarHeatHrcMult",
             "init_args": [
                 "dpa0"
             ],
             "init_kwargs": {
                 "P_pitches": [
                     45,
+                    55,
                     60,
+                    70,
+                    80,
                     90,
                     105,
                     115,
@@ -157,6 +160,9 @@
                 ],
                 "Ps": [
                     0.58,
+                    0.58,
+                    0.5,
+                    0.5,
                     0.5,
                     0.41,
                     0.7,
@@ -210,8 +216,10 @@
                 "fep_count": "fep_count",
                 "pow_states": [
                     "0xxx",
-                    "1xxx",
-                    "2xxx",
+                    "1xx0",
+                    "1xx1",
+                    "2xx0",
+                    "2xx1",
                     "3xx0",
                     "3xx1",
                     "4xx0",
@@ -234,20 +242,27 @@
             "name": "prop_heat__dpa0"
         }
     ],
-    "datestart": "2016:151:12:03:11.816",
-    "datestop": "2019:154:23:50:06.816",
+    "datestart": "2018:312:12:03:58.816",
+    "datestop": "2019:340:23:49:26.816",
     "dt": 328.0,
     "gui_config": {
-        "filename": "/home/gregg/THERMAL-MODELS/DPA-FITS/2019_JAN_HIGH_PITCH_FIT/MAY_31_2019/May_31_STEP_7.json",
+        "filename": "/home/gregg/THERMAL-MODELS/DPA-FITS/FALL_2019_RECAL/NOV_5/DEC_8_STEP_8.json",
+        "limits": {
+            "caution_hi": 39.5,
+            "planning_hi": 37.5
+        },
+        "msid": "1dpamzt",
         "plot_names": [
-            "1dpamzt data__time"
+            "1dpamzt data__time",
+            "1dpamzt resid__data",
+            "1dpamzt resid__time"
         ],
         "set_data_vals": {
             "dpa0": 20
         },
         "size": [
-            1556,
-            1029
+            1693,
+            944
         ]
     },
     "mval_names": [],
@@ -271,7 +286,7 @@
             "max": 200.0,
             "min": 0.01,
             "name": "tau",
-            "val": 1.3125
+            "val": 1.312
         },
         {
             "comp_name": "solarheat__dpa0",
@@ -281,7 +296,17 @@
             "max": 2.0,
             "min": 0.0,
             "name": "P_45",
-            "val": 0.3054384561978577
+            "val": 0.2520638538080577
+        },
+        {
+            "comp_name": "solarheat__dpa0",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__dpa0__P_55",
+            "max": 2.0,
+            "min": 0.0,
+            "name": "P_55",
+            "val": 0.3815085468694441
         },
         {
             "comp_name": "solarheat__dpa0",
@@ -291,17 +316,37 @@
             "max": 2.0,
             "min": 0.0,
             "name": "P_60",
-            "val": 0.48024947351728897
+            "val": 0.4372450750868277
         },
         {
             "comp_name": "solarheat__dpa0",
             "fmt": "{:.4g}",
             "frozen": true,
+            "full_name": "solarheat__dpa0__P_70",
+            "max": 2.0,
+            "min": 0.0,
+            "name": "P_70",
+            "val": 0.4790000740247322
+        },
+        {
+            "comp_name": "solarheat__dpa0",
+            "fmt": "{:.4g}",
+            "frozen": false,
+            "full_name": "solarheat__dpa0__P_80",
+            "max": 2.0,
+            "min": 0.0,
+            "name": "P_80",
+            "val": 0.5514100101659911
+        },
+        {
+            "comp_name": "solarheat__dpa0",
+            "fmt": "{:.4g}",
+            "frozen": false,
             "full_name": "solarheat__dpa0__P_90",
             "max": 2.0,
             "min": 0.0,
             "name": "P_90",
-            "val": 0.6440852633882019
+            "val": 0.5671192472560329
         },
         {
             "comp_name": "solarheat__dpa0",
@@ -311,7 +356,7 @@
             "max": 2.0,
             "min": 0.0,
             "name": "P_105",
-            "val": 1.046933631677255
+            "val": 1.0056772341177012
         },
         {
             "comp_name": "solarheat__dpa0",
@@ -321,7 +366,7 @@
             "max": 2.0,
             "min": 0.0,
             "name": "P_115",
-            "val": 1.28
+            "val": 1.3287533773488855
         },
         {
             "comp_name": "solarheat__dpa0",
@@ -331,7 +376,7 @@
             "max": 2.0,
             "min": 0.0,
             "name": "P_125",
-            "val": 1.6436785840631924
+            "val": 1.6140265925903434
         },
         {
             "comp_name": "solarheat__dpa0",
@@ -341,7 +386,7 @@
             "max": 2.0,
             "min": 0.0,
             "name": "P_130",
-            "val": 1.7579689633288735
+            "val": 1.734257916518779
         },
         {
             "comp_name": "solarheat__dpa0",
@@ -351,7 +396,7 @@
             "max": 3.015,
             "min": 0.0,
             "name": "P_140",
-            "val": 1.9296
+            "val": 1.8688160751122225
         },
         {
             "comp_name": "solarheat__dpa0",
@@ -361,7 +406,7 @@
             "max": 3.015143558247852,
             "min": 0.0,
             "name": "P_150",
-            "val": 2.0246140761108107
+            "val": 2.0021808953515023
         },
         {
             "comp_name": "solarheat__dpa0",
@@ -371,7 +416,7 @@
             "max": 3.015143558247852,
             "min": 0.0,
             "name": "P_160",
-            "val": 2.026
+            "val": 1.9935620604435997
         },
         {
             "comp_name": "solarheat__dpa0",
@@ -381,7 +426,7 @@
             "max": 3.015143558247852,
             "min": 0.0,
             "name": "P_170",
-            "val": 2.026
+            "val": 1.9366331319147068
         },
         {
             "comp_name": "solarheat__dpa0",
@@ -391,7 +436,7 @@
             "max": 3.015,
             "min": 0.0,
             "name": "P_180",
-            "val": 2.026
+            "val": 1.8918244039526346
         },
         {
             "comp_name": "solarheat__dpa0",
@@ -407,10 +452,40 @@
             "comp_name": "solarheat__dpa0",
             "fmt": "{:.4g}",
             "frozen": true,
+            "full_name": "solarheat__dpa0__dP_55",
+            "max": 1.0,
+            "min": 0.0,
+            "name": "dP_55",
+            "val": 0.0004681238968454087
+        },
+        {
+            "comp_name": "solarheat__dpa0",
+            "fmt": "{:.4g}",
+            "frozen": true,
             "full_name": "solarheat__dpa0__dP_60",
             "max": 1.0,
             "min": 0.0,
             "name": "dP_60",
+            "val": 0.0024941790366563407
+        },
+        {
+            "comp_name": "solarheat__dpa0",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__dpa0__dP_70",
+            "max": 1.0,
+            "min": 0.0,
+            "name": "dP_70",
+            "val": 0.0024941790366563407
+        },
+        {
+            "comp_name": "solarheat__dpa0",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "solarheat__dpa0__dP_80",
+            "max": 1.0,
+            "min": 0.0,
+            "name": "dP_80",
             "val": 0.0024941790366563407
         },
         {
@@ -441,7 +516,7 @@
             "max": 1.0,
             "min": 0.0,
             "name": "dP_115",
-            "val": 0.16072476160856392
+            "val": 0.13656843586660455
         },
         {
             "comp_name": "solarheat__dpa0",
@@ -451,7 +526,7 @@
             "max": 1.0,
             "min": 0.0,
             "name": "dP_125",
-            "val": 0.13
+            "val": 0.09337374027648246
         },
         {
             "comp_name": "solarheat__dpa0",
@@ -461,7 +536,7 @@
             "max": 1.0,
             "min": 0.0,
             "name": "dP_130",
-            "val": 0.13
+            "val": 0.09971383676490803
         },
         {
             "comp_name": "solarheat__dpa0",
@@ -471,7 +546,7 @@
             "max": 1.0,
             "min": 0.0,
             "name": "dP_140",
-            "val": 0.13
+            "val": 0.17
         },
         {
             "comp_name": "solarheat__dpa0",
@@ -491,7 +566,7 @@
             "max": 1.0,
             "min": 0.0,
             "name": "dP_160",
-            "val": 0.11
+            "val": 0.1055930424604628
         },
         {
             "comp_name": "solarheat__dpa0",
@@ -501,7 +576,7 @@
             "max": 1.0,
             "min": 0.0,
             "name": "dP_170",
-            "val": 0.1264
+            "val": 0.13175272585127878
         },
         {
             "comp_name": "solarheat__dpa0",
@@ -531,7 +606,7 @@
             "max": 1.0,
             "min": -1.0,
             "name": "ampl",
-            "val": 0.05246678962693188
+            "val": 0.03371678962693188
         },
         {
             "comp_name": "solarheat__dpa0",
@@ -551,7 +626,7 @@
             "max": 1.0,
             "min": -1.0,
             "name": "hrci_bias",
-            "val": -0.031240811843720816
+            "val": -0.04211470183005715
         },
         {
             "comp_name": "solarheat__dpa0",
@@ -561,17 +636,17 @@
             "max": 1.0,
             "min": -1.0,
             "name": "hrcs_bias",
-            "val": -0.08228808708920946
+            "val": -0.07392289472870747
         },
         {
             "comp_name": "solarheat_off_nom_roll__dpa0",
             "fmt": "{:.4g}",
-            "frozen": true,
+            "frozen": false,
             "full_name": "solarheat_off_nom_roll__dpa0__P_plus_y",
             "max": 5.0,
             "min": -5.0,
             "name": "P_plus_y",
-            "val": 1.0
+            "val": 1.6527190969037515
         },
         {
             "comp_name": "solarheat_off_nom_roll__dpa0",
@@ -581,7 +656,7 @@
             "max": 5.0,
             "min": -5.0,
             "name": "P_minus_y",
-            "val": 0.20000000000000018
+            "val": 0.55
         },
         {
             "comp_name": "heatsink__dpa0",
@@ -601,7 +676,7 @@
             "max": 200.0,
             "min": 2.0,
             "name": "tau",
-            "val": 22.963790773742538
+            "val": 24.5
         },
         {
             "comp_name": "heatsink__dpa0",
@@ -621,27 +696,47 @@
             "max": 60,
             "min": 10,
             "name": "pow_0xxx",
-            "val": 13.925718145321822
+            "val": 19.57019543816487
         },
         {
             "comp_name": "dpa_power",
             "fmt": "{:.4g}",
             "frozen": true,
-            "full_name": "dpa_power__pow_1xxx",
+            "full_name": "dpa_power__pow_1xx0",
             "max": 60,
             "min": 15,
-            "name": "pow_1xxx",
-            "val": 27.207142999370895
+            "name": "pow_1xx0",
+            "val": 28.561316078275617
         },
         {
             "comp_name": "dpa_power",
             "fmt": "{:.4g}",
             "frozen": true,
-            "full_name": "dpa_power__pow_2xxx",
+            "full_name": "dpa_power__pow_1xx1",
+            "max": 60,
+            "min": 15,
+            "name": "pow_1xx1",
+            "val": 29.26145822029714
+        },
+        {
+            "comp_name": "dpa_power",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "dpa_power__pow_2xx0",
             "max": 80,
             "min": 20,
-            "name": "pow_2xxx",
-            "val": 38.74295469570052
+            "name": "pow_2xx0",
+            "val": 39.38462543018646
+        },
+        {
+            "comp_name": "dpa_power",
+            "fmt": "{:.4g}",
+            "frozen": true,
+            "full_name": "dpa_power__pow_2xx1",
+            "max": 80,
+            "min": 20,
+            "name": "pow_2xx1",
+            "val": 39.81174008839871
         },
         {
             "comp_name": "dpa_power",
@@ -651,7 +746,7 @@
             "max": 100,
             "min": 20,
             "name": "pow_3xx0",
-            "val": 38.61525111000373
+            "val": 38.496464673348335
         },
         {
             "comp_name": "dpa_power",
@@ -661,7 +756,7 @@
             "max": 100,
             "min": 20,
             "name": "pow_3xx1",
-            "val": 50.11849071024979
+            "val": 48.8
         },
         {
             "comp_name": "dpa_power",
@@ -671,7 +766,7 @@
             "max": 120,
             "min": 20,
             "name": "pow_4xx0",
-            "val": 41.3
+            "val": 45.82396350878556
         },
         {
             "comp_name": "dpa_power",
@@ -681,7 +776,7 @@
             "max": 120,
             "min": 20,
             "name": "pow_4xx1",
-            "val": 59.05
+            "val": 55.63747978242696
         },
         {
             "comp_name": "dpa_power",
@@ -691,17 +786,17 @@
             "max": 120,
             "min": 20,
             "name": "pow_5xx0",
-            "val": 47.299170506154354
+            "val": 65.7240915977751
         },
         {
             "comp_name": "dpa_power",
             "fmt": "{:.4g}",
-            "frozen": true,
+            "frozen": false,
             "full_name": "dpa_power__pow_5xx1",
             "max": 120,
             "min": 20,
             "name": "pow_5xx1",
-            "val": 68.53192024937957
+            "val": 63.76477550650043
         },
         {
             "comp_name": "dpa_power",
@@ -711,7 +806,7 @@
             "max": 140,
             "min": 20,
             "name": "pow_6xx0",
-            "val": 57.46845648489154
+            "val": 82.4
         },
         {
             "comp_name": "dpa_power",
@@ -721,7 +816,7 @@
             "max": 140,
             "min": 20,
             "name": "pow_6xx1",
-            "val": 78.44785280868267
+            "val": 74.0
         },
         {
             "comp_name": "dpa_power",
@@ -731,7 +826,7 @@
             "max": 3.0,
             "min": 0.0,
             "name": "mult",
-            "val": 1.9000000000000001
+            "val": 2.01
         },
         {
             "comp_name": "dpa_power",
@@ -741,17 +836,17 @@
             "max": 100,
             "min": 0.0,
             "name": "bias",
-            "val": 0.01
+            "val": 0.0
         },
         {
             "comp_name": "prop_heat__dpa0",
             "fmt": "{:.4g}",
             "frozen": true,
             "full_name": "prop_heat__dpa0__k",
-            "max": 2.0,
+            "max": 3.0,
             "min": 0.0,
             "name": "k",
-            "val": 0.255
+            "val": 0.210625
         },
         {
             "comp_name": "prop_heat__dpa0",
@@ -761,7 +856,7 @@
             "max": 100.0,
             "min": -50.0,
             "name": "T_set",
-            "val": 12.951093536564954
+            "val": 13.7
         }
     ],
     "tlm_code": null


### PR DESCRIPTION
Update DPA parameter fit. This fit uses the new solar heat option (xija PR# 66 "Add option for multiplicative yearly dependence of solar heating"), which is included in Xija version 4.15 or later.