### PR TITLE
Update PFTANK2T model, includes state power parameter

### DIFF
--- a/chandra_models/__init__.py
+++ b/chandra_models/__init__.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from .get_model_spec import *
 
-__version__ = '3.32'
+__version__ = '3.33'
 
 

--- a/chandra_models/xija/pftank2t/pftank2t_spec.json
+++ b/chandra_models/xija/pftank2t/pftank2t_spec.json
@@ -1,4 +1,5 @@
 {
+    "bad_times": [],
     "comps": [
         {
             "class_name": "Node",
@@ -60,9 +61,11 @@
                     140,
                     150,
                     160,
-                    170
+                    170,
+                    180
                 ],
                 [
+                    0,
                     0,
                     0,
                     0,
@@ -121,33 +124,61 @@
                 "roll_comp": "roll"
             },
             "name": "solarheat_off_nom_roll__pf0tank2t"
+        },
+        {
+            "class_name": "MsidStatePower",
+            "init_args": [],
+            "init_kwargs": {
+                "P": 0.5,
+                "node": "pf0tank2t",
+                "state_msid": "COSSRBX",
+                "state_val": "ON "
+            },
+            "name": "cossrbx_on"
         }
     ],
-    "datestart": "2014:150:12:09:12.816",
-    "datestop": "2018:150:11:48:30.816",
+    "datestart": "2016:262:00:01:27.816",
+    "datestop": "2019:365:23:52:54.816",
     "dt": 328.0,
+    "evolve_method": 1,
+    "gui_config": {
+        "filename": "/Users/mdahmer/WIP/xija_state_power/pftank2t_spec_msid_power_days-1200_end-2020001.json",
+        "plot_names": [
+            "pftank2t data__time",
+            "pftank2t resid__time",
+            "solarheat__pf0tank2t solar_heat__pitch"
+        ],
+        "set_data_vals": {
+            "pf0tank2t": 25
+        },
+        "size": [
+            1780,
+            1110
+        ]
+    },
+    "limits": {},
     "mval_names": [],
     "name": "pftank2t",
     "pars": [
         {
             "comp_name": "heatsink__pf0tank2t",
             "fmt": "{:.4g}",
-            "frozen": true,
+            "frozen": false,
             "full_name": "heatsink__pf0tank2t__T",
             "max": 100.0,
             "min": -300.0,
             "name": "T",
-            "val": 8.575608673512326
+            "val": 9.21282062086986
         },
         {
             "comp_name": "heatsink__pf0tank2t",
             "fmt": "{:.4g}",
-            "frozen": true,
+            "frozen": false,
             "full_name": "heatsink__pf0tank2t__tau",
             "max": 800.0,
             "min": 2.0,
             "name": "tau",
-            "val": 208.82797912337148
+            "val": 210.03935698605534
         },
         {
             "comp_name": "prop_heat__pf0tank2t",
@@ -172,102 +203,112 @@
         {
             "comp_name": "solarheat__pf0tank2t",
             "fmt": "{:.4g}",
-            "frozen": true,
+            "frozen": false,
             "full_name": "solarheat__pf0tank2t__P_45",
             "max": 1.0,
-            "min": -1.0,
+            "min": 0.0,
             "name": "P_45",
-            "val": 0.2068967063756976
+            "val": 0.1932567422499163
         },
         {
             "comp_name": "solarheat__pf0tank2t",
             "fmt": "{:.4g}",
-            "frozen": true,
+            "frozen": false,
             "full_name": "solarheat__pf0tank2t__P_60",
             "max": 1.0,
-            "min": -1.0,
+            "min": 0.0,
             "name": "P_60",
-            "val": 0.2139244797517381
+            "val": 0.19149871681163744
         },
         {
             "comp_name": "solarheat__pf0tank2t",
             "fmt": "{:.4g}",
-            "frozen": true,
+            "frozen": false,
             "full_name": "solarheat__pf0tank2t__P_80",
             "max": 1.0,
-            "min": -1.0,
+            "min": 0.0,
             "name": "P_80",
-            "val": 0.1889964479800537
+            "val": 0.16751843558912738
         },
         {
             "comp_name": "solarheat__pf0tank2t",
             "fmt": "{:.4g}",
-            "frozen": true,
+            "frozen": false,
             "full_name": "solarheat__pf0tank2t__P_100",
             "max": 1.0,
-            "min": -1.0,
+            "min": 0.0,
             "name": "P_100",
-            "val": 0.1372975781199931
+            "val": 0.1394320145005823
         },
         {
             "comp_name": "solarheat__pf0tank2t",
             "fmt": "{:.4g}",
-            "frozen": true,
+            "frozen": false,
             "full_name": "solarheat__pf0tank2t__P_120",
             "max": 1.0,
-            "min": -1.0,
+            "min": 0.0,
             "name": "P_120",
-            "val": 0.105
+            "val": 0.09240260720651433
         },
         {
             "comp_name": "solarheat__pf0tank2t",
             "fmt": "{:.4g}",
-            "frozen": true,
+            "frozen": false,
             "full_name": "solarheat__pf0tank2t__P_130",
             "max": 1.0,
-            "min": -1.0,
+            "min": 0.0,
             "name": "P_130",
-            "val": 0.0900542858655144
+            "val": 0.06490592449616198
         },
         {
             "comp_name": "solarheat__pf0tank2t",
             "fmt": "{:.4g}",
-            "frozen": true,
+            "frozen": false,
             "full_name": "solarheat__pf0tank2t__P_140",
             "max": 1.0,
             "min": -1.0,
             "name": "P_140",
-            "val": 0.05
+            "val": 0.051529551531811144
         },
         {
             "comp_name": "solarheat__pf0tank2t",
             "fmt": "{:.4g}",
-            "frozen": true,
+            "frozen": false,
             "full_name": "solarheat__pf0tank2t__P_150",
             "max": 1.0,
             "min": -1.0,
             "name": "P_150",
-            "val": 0.005209567154263458
+            "val": 0.013593359919904364
         },
         {
             "comp_name": "solarheat__pf0tank2t",
             "fmt": "{:.4g}",
-            "frozen": true,
+            "frozen": false,
             "full_name": "solarheat__pf0tank2t__P_160",
             "max": 1.0,
             "min": -1.0,
             "name": "P_160",
-            "val": -0.038
+            "val": -0.01623358390968195
         },
         {
             "comp_name": "solarheat__pf0tank2t",
             "fmt": "{:.4g}",
-            "frozen": true,
+            "frozen": false,
             "full_name": "solarheat__pf0tank2t__P_170",
             "max": 1.0,
             "min": -1.0,
             "name": "P_170",
-            "val": -0.1
+            "val": -0.05847173444250406
+        },
+        {
+            "comp_name": "solarheat__pf0tank2t",
+            "fmt": "{:.4g}",
+            "frozen": false,
+            "full_name": "solarheat__pf0tank2t__P_180",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "P_180",
+            "val": -0.18972304672870993
         },
         {
             "comp_name": "solarheat__pf0tank2t",
@@ -275,9 +316,9 @@
             "frozen": false,
             "full_name": "solarheat__pf0tank2t__dP_45",
             "max": 1.0,
-            "min": -1.0,
+            "min": 0.0,
             "name": "dP_45",
-            "val": 0.01460314201627873
+            "val": 0.009270393578692745
         },
         {
             "comp_name": "solarheat__pf0tank2t",
@@ -287,7 +328,7 @@
             "max": 1.0,
             "min": -1.0,
             "name": "dP_60",
-            "val": 0.014
+            "val": 0.012244917311411519
         },
         {
             "comp_name": "solarheat__pf0tank2t",
@@ -297,7 +338,7 @@
             "max": 1.0,
             "min": -1.0,
             "name": "dP_80",
-            "val": 0.013001577387206552
+            "val": 0.01712288724603777
         },
         {
             "comp_name": "solarheat__pf0tank2t",
@@ -307,7 +348,7 @@
             "max": 1.0,
             "min": -1.0,
             "name": "dP_100",
-            "val": 0.010943630538112231
+            "val": 0.012428579581755934
         },
         {
             "comp_name": "solarheat__pf0tank2t",
@@ -317,7 +358,7 @@
             "max": 1.0,
             "min": -1.0,
             "name": "dP_120",
-            "val": 0.014
+            "val": 0.022566109329260654
         },
         {
             "comp_name": "solarheat__pf0tank2t",
@@ -327,7 +368,7 @@
             "max": 1.0,
             "min": -1.0,
             "name": "dP_130",
-            "val": 0.0157726256194432
+            "val": 0.02480128942844609
         },
         {
             "comp_name": "solarheat__pf0tank2t",
@@ -337,7 +378,7 @@
             "max": 1.0,
             "min": -1.0,
             "name": "dP_140",
-            "val": 0.015
+            "val": 0.010953951535115455
         },
         {
             "comp_name": "solarheat__pf0tank2t",
@@ -347,7 +388,7 @@
             "max": 1.0,
             "min": -1.0,
             "name": "dP_150",
-            "val": 0.01568988351517002
+            "val": 0.01130417545218269
         },
         {
             "comp_name": "solarheat__pf0tank2t",
@@ -357,7 +398,7 @@
             "max": 1.0,
             "min": -1.0,
             "name": "dP_160",
-            "val": 0.015
+            "val": 0.0026794666263182387
         },
         {
             "comp_name": "solarheat__pf0tank2t",
@@ -367,7 +408,17 @@
             "max": 1.0,
             "min": -1.0,
             "name": "dP_170",
-            "val": 0.015
+            "val": 0.0011620456983372808
+        },
+        {
+            "comp_name": "solarheat__pf0tank2t",
+            "fmt": "{:.4g}",
+            "frozen": false,
+            "full_name": "solarheat__pf0tank2t__dP_180",
+            "max": 1.0,
+            "min": -1.0,
+            "name": "dP_180",
+            "val": 0.02597260805298488
         },
         {
             "comp_name": "solarheat__pf0tank2t",
@@ -387,7 +438,7 @@
             "max": 1.0,
             "min": -1.0,
             "name": "ampl",
-            "val": 0.00968256506377037
+            "val": 0.008626430932138447
         },
         {
             "comp_name": "solarheat__pf0tank2t",
@@ -402,33 +453,44 @@
         {
             "comp_name": "coupling__pftank2t__pf0tank2t",
             "fmt": "{:.4g}",
-            "frozen": true,
+            "frozen": false,
             "full_name": "coupling__pftank2t__pf0tank2t__tau",
             "max": 800.0,
             "min": 2.0,
             "name": "tau",
-            "val": 389.5234147288561
+            "val": 392.7359132489197
         },
         {
             "comp_name": "solarheat_off_nom_roll__pf0tank2t",
             "fmt": "{:.4g}",
-            "frozen": true,
+            "frozen": false,
             "full_name": "solarheat_off_nom_roll__pf0tank2t__P_plus_y",
             "max": 3.0,
             "min": -3.0,
             "name": "P_plus_y",
-            "val": -0.067505031507498
+            "val": -0.011716047917025515
         },
         {
             "comp_name": "solarheat_off_nom_roll__pf0tank2t",
             "fmt": "{:.4g}",
-            "frozen": true,
+            "frozen": false,
             "full_name": "solarheat_off_nom_roll__pf0tank2t__P_minus_y",
             "max": 3.0,
             "min": -3.0,
             "name": "P_minus_y",
-            "val": -0.058252789515748346
+            "val": -0.10481415257366875
+        },
+        {
+            "comp_name": "cossrbx_on__pf0tank2t",
+            "fmt": "{:.4g}",
+            "frozen": false,
+            "full_name": "cossrbx_on__pf0tank2t__P",
+            "max": 2.0,
+            "min": -2.0,
+            "name": "P",
+            "val": 0.004859426906919793
         }
     ],
+    "rk4": 0,
     "tlm_code": null
 }


### PR DESCRIPTION
This PR updates the IPS Fuel Tank model with a full refit and uses the new MSIDStatePower Xija component. This requires Xija version 4.21.0 or later.