### PR TITLE
Add planning high and penalty high limits for ACA xija model

### DIFF
--- a/chandra_models/xija/aca/aca_spec.json
+++ b/chandra_models/xija/aca/aca_spec.json
@@ -234,7 +234,12 @@
             1276
         ]
     },
-    "limits": {},
+    "limits": {
+        "aacccdpt": {
+            "planning.warning.high": -5.8,
+            "planning.penalty.high": -6.8
+        }
+    },
     "mval_names": [],
     "name": "aacccdpt",
     "pars": [


### PR DESCRIPTION
This implements the change in the ACA planning limit that was approved at SS&AWG 6/23 and at MPCWG 6/16.

This is a precursor for corresponding updates in proseco and potentially MATLAB tools to use the new `limits` values.

## Testing

- [x] Functional testing with xija gui fit to see the limit lines drawn in the expected place.

![image](https://user-images.githubusercontent.com/348089/123153397-9bf6de80-d433-11eb-8797-dfcb62f8568a.png)
