### PR TITLE
Add LETG specific planning limit to OBA model

### DIFF
--- a/chandra_models/__init__.py
+++ b/chandra_models/__init__.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from .get_model_spec import *
 
-__version__ = '3.37'
+__version__ = '3.37.1'
 
 
 

--- a/chandra_models/xija/fwdblkhd/4rt700t_spec.json
+++ b/chandra_models/xija/fwdblkhd/4rt700t_spec.json
@@ -186,6 +186,7 @@
             "odb.caution.high": 110,
             "odb.warning.high": 140,
             "planning.warning.high": 103,
+            "planning.warning.high.letg": 102,
             "unit": "degF"
         }
     },


### PR DESCRIPTION
This release updates the OBA thermal model to include a LETG-specific thermal limit. No changes were made that affect model performance.

Files Modified:
 - chandra_models/xija/fwdblkhd/4rt700t_spec.json
 - chandra_models/__init__.py