### PR TITLE
Increase ACA planning limits

### DIFF
--- a/chandra_models/xija/aca/aca_spec.json
+++ b/chandra_models/xija/aca/aca_spec.json
@@ -236,8 +236,8 @@
     },
     "limits": {
         "aacccdpt": {
-            "planning.warning.high": -5.8,
-            "planning.penalty.high": -6.8,
+            "planning.warning.high": -5.2,
+            "planning.penalty.high": -6.2,
             "unit": "degC"
         }
     },


### PR DESCRIPTION
This PR increases both the planning.warning.high and planning.penalty.high limits for the ACA model. This is a limit-only update.