### PR TITLE
Update ACA model to include impact of FA6 heater

### DIFF
--- a/chandra_models/xija/aca/aca_fit_script_full_fit.py
+++ b/chandra_models/xija/aca/aca_fit_script_full_fit.py
@@ -1,0 +1,38 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+import xija
+import sys
+from os.path import expanduser
+
+home = expanduser("~")
+addthispath = home + '/AXAFLIB/xijafit/'
+sys.path.insert(0, addthispath)
+import xijafit
+
+stars = '*'*80
+n = 0
+
+newmodel = xijafit.XijaFit('aca_spec_new.json', start='2018:001', stop='2022:100',
+    set_data_exprs=(u'aca0=-10.0',), quiet=False, name='aacccdpt')
+
+n = n + 1
+print('{}\nStep {}\n{}'.format(stars, n, stars))
+newmodel.freeze_all()
+
+newmodel.thaw_solarheat_p()
+newmodel.thaw_solarheat_dp()
+newmodel.thaw_param(u'solarheat__aca0__ampl')
+
+newmodel.thaw_param(u'heatsink__aca0__tau')
+newmodel.thaw_param(u'heatsink__aca0__T')
+
+newmodel.thaw_param(u'coupling__aacccdpt__aca0')
+
+newmodel.thaw_param(u'fa6_enab__aca0')
+
+newmodel.fit(method='moncar')
+
+newmodel.write_spec_file('.aca_spec_new_mod.json')
+newmodel.write_snapshots_file('./aca_spec_new_mod_snapshots.json')
+
+

--- a/chandra_models/xija/aca/aca_spec_msid_state_power_fa6.json
+++ b/chandra_models/xija/aca/aca_spec_msid_state_power_fa6.json
@@ -215,15 +215,15 @@
             "name": "step_power_5__aca0"
         },
         {
-            "class_name": "StepFunctionPower",
+            "class_name": "MsidStatePower",
             "init_args": [],
             "init_kwargs": {
-                "P": -0.5,
-                "id": "_6",
+                "P": 0.5,
                 "node": "aca0",
-                "time": "2022:040:17:31:50"
+                "state_msid": "3AZF6HTA",
+                "state_val": "ENAB"
             },
-            "name": "step_power_6__aca0"
+            "name": "3azf6hta_enab"
         }
     ],
     "datestart": "2018:001:00:02:06.816",
@@ -601,10 +601,10 @@
             "val": -0.06
         },
         {
-            "comp_name": "step_power_6__aca0",
+            "comp_name": "fa6_enab__aca0",
             "fmt": "{:.4g}",
             "frozen": false,
-            "full_name": "step_power_6__aca0__P",
+            "full_name": "fa6_enab__aca0__P",
             "max": 5.0,
             "min": -5.0,
             "name": "P",


### PR DESCRIPTION
This updates the ACA model with a hardcoded step increase in power starting 2022:040:17:31:50 to accommodate the FA6 heater state. Note that once the FA6 is turned off, this model will need to be adjusted to reflect the new state.