### PR TITLE
Add limits to pm2thv1t_spec_matlab.json

### DIFF
--- a/chandra_models/__init__.py
+++ b/chandra_models/__init__.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from .get_model_spec import *
 
-__version__ = '3.41'
+__version__ = '3.41.1'
 
 
 

--- a/chandra_models/xija/mups_valve/pm2thv1t_spec_matlab.json
+++ b/chandra_models/xija/mups_valve/pm2thv1t_spec_matlab.json
@@ -81800,7 +81800,13 @@
     "datestop": "2021:365:23:52:22.816",
     "dt": 328.0,
     "evolve_method": 2,
-    "limits": {},
+    "limits": {
+        "pm2thv1t": {
+            "odb.warning.high": 240,
+            "planning.warning.high": 210,
+            "unit": "degF"
+        }
+    },
     "mval_names": [],
     "name": "pm2thv1t",
     "pars": [


### PR DESCRIPTION
This PR adds back the planning and caution limits for the MUPS2A `pm2thv1t_spec_matlab.json`  model.