### PR TITLE
Increase ACA limits, increment version

### DIFF
--- a/chandra_models/__init__.py
+++ b/chandra_models/__init__.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from .get_model_spec import *
 
-__version__ = '3.44'
+__version__ = '3.45'
 
 
 

--- a/chandra_models/xija/aca/aca_spec.json
+++ b/chandra_models/xija/aca/aca_spec.json
@@ -262,8 +262,8 @@
     },
     "limits": {
         "aacccdpt": {
-            "planning.penalty.high": -6.2,
-            "planning.warning.high": -5.2,
+            "planning.penalty.high": -5.5,
+            "planning.warning.high": -4.5,
             "unit": "degC"
         }
     },


### PR DESCRIPTION
PR #96 makes the following changes:
 - `aca_spec.json`: Increments `planning.penalty.high` from -6.2C to -5.5C, Increments `planning.warning.high` from -5.2C to -4.5C. 
 - `__init__.json`: Increment version from 3.44 to 3.45 (major version number increment intended to account for ACA drift model inclusion as well)

Files Added:
 - None

Files Removed:
 - None