### PR TITLE
Update 4RT700T planning.warning.high limit

### DIFF
--- a/chandra_models/xija/fwdblkhd/4rt700t_spec.json
+++ b/chandra_models/xija/fwdblkhd/4rt700t_spec.json
@@ -196,7 +196,7 @@
         "4rt700t": {
             "odb.caution.high": 110,
             "odb.warning.high": 140,
-            "planning.warning.high": 103,
+            "planning.warning.high": 106,
             "planning.warning.low": 73,
             "unit": "degF"
         }


### PR DESCRIPTION
This PR updates the `planning.warning.high` limit from 103F to 106F.