### PR TITLE
Update penalty limit to -4.0 C in aca_spec.json

### DIFF
--- a/chandra_models/xija/aca/aca_spec.json
+++ b/chandra_models/xija/aca/aca_spec.json
@@ -273,7 +273,7 @@
     },
     "limits": {
         "aacccdpt": {
-            "planning.penalty.high": -5.5,
+            "planning.penalty.high": -4.0,
             "planning.warning.high": -4.5,
             "unit": "degC"
         }


### PR DESCRIPTION
## Description

Per discussion at the SS&AWG and TWG, the ACA penalty limit is being effectively eliminated from use in proseco and sparkles evaluation of catalogs.

Per discussion at the Matlab WG on 6/14, we are implementing this by making the penalty limit be 0.5 deg higher than the planning limit. In all realistic cases this mean the penalty will not apply.

## Testing

To be done by the FOT.