### PR TITLE
Update aca_spec.json to remove the ACA penalty limit

### DIFF
--- a/chandra_models/xija/aca/aca_spec.json
+++ b/chandra_models/xija/aca/aca_spec.json
@@ -273,7 +273,6 @@
     },
     "limits": {
         "aacccdpt": {
-            "planning.penalty.high": -4.0,
             "planning.warning.high": -4.5,
             "unit": "degC"
         }


### PR DESCRIPTION
## Description

Per prior discussion this removes the ACA penalty limit from the ACA thermal model spec file. Tools that use this limit have been modified to work with or without this limit in the spec file:

- https://github.com/sot/proseco/pull/384
- https://github.com/sot/starcheck/pull/429
- MATLAB tools ticket  MATLAB-12026

## Interface impact

This will remove the `["limits"]["aacccdpt"]["planning.penalty_high"]` attribute

## Testing

Julia reported verbally that she tested this in MATLAB tools. The individual PR's have been likewise tested. 