### PR TITLE
Add -105C ACISFP limit, decrease CEA limit to 9.5C

### DIFF
--- a/chandra_models/__init__.py
+++ b/chandra_models/__init__.py
@@ -1,4 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from .get_model_spec import *
 
-__version__ = '3.49'
+__version__ = '3.49.1'

--- a/chandra_models/xija/acisfp/acisfp_spec.json
+++ b/chandra_models/xija/acisfp/acisfp_spec.json
@@ -579,6 +579,7 @@
             "planning.data_quality.high.acisi": -112.0,
             "planning.data_quality.high.aciss": -111.0,
             "planning.data_quality.high.aciss_hot": -109.0,
+            "planning.data_quality.high.aciss_hot_b": -105.0,
             "planning.data_quality.high.cold_ecs": -118.2,
             "planning.warning.high": -86.0,
             "safety.caution.high": -80.0,

--- a/chandra_models/xija/acisfp/acisfp_spec_matlab.json
+++ b/chandra_models/xija/acisfp/acisfp_spec_matlab.json
@@ -579,6 +579,7 @@
             "planning.data_quality.high.acisi": -112.0,
             "planning.data_quality.high.aciss": -111.0,
             "planning.data_quality.high.aciss_hot": -109.0,
+            "planning.data_quality.high.aciss_hot_b": -105.0,
             "planning.data_quality.high.cold_ecs": -118.2,
             "planning.warning.high": -86.0,
             "safety.caution.high": -80.0,

--- a/chandra_models/xija/hrc/cea_spec.json
+++ b/chandra_models/xija/hrc/cea_spec.json
@@ -324,7 +324,7 @@
     "limits": {
         "2ceahvpt": {
             "odb.caution.high": 12,
-            "planning.warning.high": 10,
+            "planning.warning.high": 9.5,
             "unit": "degC"
         }
     },


### PR DESCRIPTION
This PR includes the following changes:

 - chandra_models/xija/acisfp_spec.json: Add -105.0C hot ACIS "b" limit
 - chandra_models/xija/acisfp_spec_matlab.json: Add -105.0C hot ACIS "b" limit
 - chandra_models/xija/cea/cea_spec.json: decrease planning limit from 10.0C to 9.5C
 - chandra_models/__init__.py: increment version from 3.49 to 3.49.1
