### PR TITLE
Update limits in currently used mups model spec files

### DIFF
--- a/chandra_models/__init__.py
+++ b/chandra_models/__init__.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from .get_model_spec import *
 
-__version__ = '3.52'
+__version__ = '3.52.1'
 

--- a/chandra_models/xija/mups_valve/pm1thv2t_spec.json
+++ b/chandra_models/xija/mups_valve/pm1thv2t_spec.json
@@ -210,7 +210,7 @@
     "limits": {
         "pm1thv2t": {
             "odb.warning.high": 240,
-            "planning.warning.high": 210,
+            "planning.warning.high": 215,
             "unit": "degF"
         }
     },

--- a/chandra_models/xija/mups_valve/pm2thv1t_spec_matlab.json
+++ b/chandra_models/xija/mups_valve/pm2thv1t_spec_matlab.json
@@ -81803,7 +81803,7 @@
     "limits": {
         "pm2thv1t": {
             "odb.warning.high": 240,
-            "planning.warning.high": 210,
+            "planning.warning.high": 215,
             "unit": "degF"
         }
     },


### PR DESCRIPTION
This PR updates the two production mups model spec files to reflect the new `planning.warning.high` thermal limit of 215F and bumps the version from 3.52 to 3.52.1.

Files Modified:
 - chandra_models/xija/mups_valve/pm1thv2t_spec.json: Limit updates only
 - chandra_models/xija/mups_valve/pm2thv1t_spec_matlab.json: Limit updates only
 - chandra_models/\_\_init\_\_.py: version increment

Files Added: None

Files Removed: None

