### PR TITLE
Update OTG limits to hetg: 73, letg: 77

### DIFF
--- a/chandra_models/xija/fwdblkhd/4rt700t_spec.json
+++ b/chandra_models/xija/fwdblkhd/4rt700t_spec.json
@@ -197,7 +197,8 @@
             "odb.caution.high": 110,
             "odb.warning.high": 140,
             "planning.warning.high": 106,
-            "planning.warning.low": 73,
+            "planning.warning.low.hetg": 73,
+            "planning.warning.low.letg": 77,
             "unit": "degF"
         }
     },

--- a/chandra_models/xija/fwdblkhd/4rt700t_spec.json
+++ b/chandra_models/xija/fwdblkhd/4rt700t_spec.json
@@ -197,6 +197,7 @@
             "odb.caution.high": 110,
             "odb.warning.high": 140,
             "planning.warning.high": 106,
+            "planning.warning.low": 73,
             "planning.warning.low.hetg": 73,
             "planning.warning.low.letg": 77,
             "unit": "degF"


### PR DESCRIPTION
This PR updates the OBA Forward Bulkhead model with new separate OTG limits.

Files Modified:
 - chandra_models/xija/fwdblkhd/4rt700t_spec.json: Limit updates only

Files Added: None

Files Removed: None