### PR TITLE
Update HRC limit back to 10C, Increment version to 3.53.1

### DIFF
--- a/chandra_models/__init__.py
+++ b/chandra_models/__init__.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from .get_model_spec import *
 
-__version__ = '3.53'
+__version__ = '3.53.1'
 
 

--- a/chandra_models/xija/hrc/cea_spec.json
+++ b/chandra_models/xija/hrc/cea_spec.json
@@ -328,7 +328,7 @@
     "limits": {
         "2ceahvpt": {
             "odb.caution.high": 12,
-            "planning.warning.high": 9.5,
+            "planning.warning.high": 10,
             "unit": "degC"
         }
     },


### PR DESCRIPTION
This PR updates the HRC CEA planning limit to 10C, consistent with the currently approved guideline.

Files Modified:
 - chandra_models/\_\_init\_\_.py: version increment to 3.53.1
 - chandra_models/xija/hrc/cea_spec.json: Limit updates only

Files Added: None

Files Removed: None