### PR TITLE
Update MUPS Planning Limits to 227.5F

### DIFF
--- a/chandra_models/__init__.py
+++ b/chandra_models/__init__.py
@@ -1,4 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from .get_model_spec import *
 
-__version__ = '3.67.0'
+__version__ = '3.67.1'

--- a/chandra_models/xija/mups_valve/pm1thv2t_spec.json
+++ b/chandra_models/xija/mups_valve/pm1thv2t_spec.json
@@ -141,7 +141,7 @@
   "limits": {
     "pm1thv2t": {
       "odb.warning.high": 240,
-      "planning.warning.high": 225,
+      "planning.warning.high": 227.5,
       "unit": "degF"
     }
   },

--- a/chandra_models/xija/mups_valve/pm2thv1t_spec_matlab.json
+++ b/chandra_models/xija/mups_valve/pm2thv1t_spec_matlab.json
@@ -81803,7 +81803,7 @@
     "limits": {
         "pm2thv1t": {
             "odb.warning.high": 240,
-            "planning.warning.high": 225,
+            "planning.warning.high": 227.5,
             "unit": "degF"
         }
     },


### PR DESCRIPTION
This PR updates the MUPS planning limit to 227.5F, consistent with the currently approved guideline.

Files Modified:
chandra_models/xija/mups_valve/pm1thv2t_spec.json: Limit updates only
chandra_models/xija/mups_valve/pm2thv1t_spec_matlab.json: Limit updates only

Files Added: None

Files Removed: None