### PR TITLE
TPC_FSSE Limit Update Febuary 2026

### DIFF
--- a/chandra_models/__init__.py
+++ b/chandra_models/__init__.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from .get_model_spec import *
 
-__version__ = '3.73.0'
+__version__ = '3.73.1'
 

--- a/chandra_models/xija/tpc_fsse/tpc_fsse_spec.json
+++ b/chandra_models/xija/tpc_fsse/tpc_fsse_spec.json
@@ -155,7 +155,7 @@
         "tpc_fsse": {
             "odb.caution.high": 128,
             "odb.warning.high": 130,
-            "planning.warning.high": 122,
+            "planning.warning.high": 121,
             "unit": "degF"
         }
     },


### PR DESCRIPTION
This PR updates the Fine Sun Sensor Electronics planning limit to 121.0F, consistent with the currently approved guideline.

Files Modified:
chandra_models/xija/tpc_fsse/tpc_fsse_spec.json: Limit updates only
chandra_models/\_\_init\_\_.py: Bump version to 3.73.1

Files Added:
None

Files Removed:
None