### PR TITLE
ACA Limit Update June 2026

### DIFF
--- a/chandra_models/__init__.py
+++ b/chandra_models/__init__.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from .get_model_spec import *
 
-__version__ = '3.74.0'
+__version__ = '3.74.1'
 

--- a/chandra_models/xija/aca/aca_spec.json
+++ b/chandra_models/xija/aca/aca_spec.json
@@ -295,7 +295,7 @@
     },
     "limits": {
         "aacccdpt": {
-            "planning.warning.high": -2.1,
+            "planning.warning.high": -1.5,
             "unit": "degC"
         }
     },


### PR DESCRIPTION
This PR updates the ACA planning limit to -1.5C, consistent with the currently approved guideline.

Files Modified:
chandra_models/xija/aca/aca_spec.json: Limit updates only
chandra_models/__init__.py: Bump version to 3.74.1

Files Added:
None

Files Removed:
None